### PR TITLE
fix(test): tighten api/chat ServerResponse mock cast (unbreak CI typecheck)

### DIFF
--- a/api/chat.test.ts
+++ b/api/chat.test.ts
@@ -90,13 +90,19 @@ function makeRes(): CapturedRes {
     },
   });
 
-  const res = writable as unknown as ServerResponse & {
+  // Internal mock shape — looser signatures than ServerResponse (whose
+  // setHeader/writeHead/end return `this` for chaining). Intersecting the
+  // strict ServerResponse type with these void-returning stubs is unsatisfiable
+  // under TS strict mode, so we type the mock as a standalone surface and cast
+  // to ServerResponse only at the export boundary.
+  const mock = writable as unknown as {
+    statusCode: number;
     setHeader: (k: string, v: string | number) => void;
     writeHead: (s: number, h?: Record<string, string | number>) => void;
     end: (payload?: string | Buffer) => void;
   };
 
-  Object.defineProperty(res, 'statusCode', {
+  Object.defineProperty(mock, 'statusCode', {
     get: () => statusCode,
     set: (v: number) => {
       statusCode = v;
@@ -104,17 +110,17 @@ function makeRes(): CapturedRes {
     configurable: true,
   });
 
-  res.setHeader = (k: string, v: string | number) => {
+  mock.setHeader = (k, v) => {
     headers[k.toLowerCase()] = String(v);
   };
-  res.writeHead = (s: number, h?: Record<string, string | number>) => {
+  mock.writeHead = (s, h) => {
     statusCode = s;
     if (h) {
       for (const [k, v] of Object.entries(h)) headers[k.toLowerCase()] = String(v);
     }
   };
   const origEnd = writable.end.bind(writable);
-  res.end = (payload?: string | Buffer) => {
+  mock.end = (payload) => {
     if (typeof payload === 'string') chunks.push(Buffer.from(payload));
     else if (Buffer.isBuffer(payload)) chunks.push(payload);
     ended = true;
@@ -122,7 +128,7 @@ function makeRes(): CapturedRes {
   };
 
   return {
-    res,
+    res: mock as unknown as ServerResponse,
     headers,
     getStatus: () => statusCode,
     getBody: () => Buffer.concat(chunks).toString(),


### PR DESCRIPTION
## Summary

Unbreaks the **Typecheck (server)** CI step, which has failed for 3 consecutive commits to `main` since `ed7ca32` ("test(api/chat): add integration tests for the chat handler"). The doc-only commits that landed after it (`73aa658`, `cbed404`, `3bb2731`) all inherited the red signal but went unnoticed because no source code changed.

## Root cause

`api/chat.test.ts:93` cast the mock writable to `ServerResponse & { setHeader: (k, v) => void; writeHead: ...; end: ... }`. The real `ServerResponse.setHeader` returns `this` for chaining; intersecting that with a `void`-returning override is unsatisfiable under TS strict mode. TypeScript correctly flagged it with three `TS2322` errors at lines 107 / 110 / 117.

`pnpm test:run` (vitest) kept passing at runtime (106/106) because vitest doesn't run a strict typecheck — only the `tsc -p server/tsconfig.json --noEmit` step in CI exposed the regression.

## Fix

Type the internal mock as a standalone surface (no intersection with `ServerResponse`), then cast to `ServerResponse` only at the returned-`res` boundary. Same 4 properties exposed (`statusCode` + `setHeader` / `writeHead` / `end`); zero behavioural change; the 17 existing handler call sites stay untouched.

## Verification

- [x] `pnpm exec tsc -p server/tsconfig.json --noEmit` — zero errors (was 3)
- [x] `pnpm exec tsc -b` — zero errors
- [x] `pnpm test:run` — 106/106 still passing