### PR TITLE
feat(chat): D-12 server-side AbortSignal propagation

### DIFF
--- a/api/chat.test.ts
+++ b/api/chat.test.ts
@@ -112,6 +112,7 @@ function makeRes(): CapturedRes {
   // to ServerResponse only at the export boundary.
   const mock = writable as unknown as {
     statusCode: number;
+    writableEnded: boolean;
     setHeader: (k: string, v: string | number) => void;
     writeHead: (s: number, h?: Record<string, string | number>) => void;
     end: (payload?: string | Buffer) => void;
@@ -122,6 +123,16 @@ function makeRes(): CapturedRes {
     set: (v: number) => {
       statusCode = v;
     },
+    configurable: true,
+  });
+
+  // vite-plugin-node-polyfills swaps node:stream → readable-stream@3 in the
+  // bundled test runtime, which lacks the `writableEnded` getter that real
+  // Node ServerResponse exposes. api/chat.ts uses this to guard the
+  // `req.on('close')` listener (don't abort if the response already ended);
+  // mirror that surface here so the close-listener tests behave like prod.
+  Object.defineProperty(mock, 'writableEnded', {
+    get: () => ended,
     configurable: true,
   });
 
@@ -355,6 +366,47 @@ describe('api/chat handler', () => {
     const cap = makeRes();
     await handler(makeReq({ body: validBody() }), cap.res);
     expect(chatMocks.lastSignal).toBeInstanceOf(AbortSignal);
+    expect(chatMocks.lastSignal?.aborted).toBe(false);
+  });
+
+  it('aborts the AbortSignal when req emits close before res.writableEnded', async () => {
+    let releaseStream: () => void = () => {};
+    chatMocks.streamGate = new Promise<void>((r) => {
+      releaseStream = r;
+    });
+    ratelimitMocks.next = {
+      ok: true,
+      limit: 30,
+      remaining: 29,
+      reset: Date.now() + 60_000,
+    };
+
+    const req = makeReq({ body: validBody() });
+    const cap = makeRes();
+    const handlerDone = handler(req, cap.res);
+
+    await new Promise((r) => setImmediate(r));
+    expect(chatMocks.lastSignal?.aborted).toBe(false);
+
+    (req as unknown as Readable).emit('close');
+    expect(chatMocks.lastSignal?.aborted).toBe(true);
+
+    releaseStream();
+    await handlerDone;
+  });
+
+  it('does not abort the AbortSignal when req emits close after res.writableEnded', async () => {
+    ratelimitMocks.next = {
+      ok: true,
+      limit: 30,
+      remaining: 29,
+      reset: Date.now() + 60_000,
+    };
+    const req = makeReq({ body: validBody() });
+    const cap = makeRes();
+    await handler(req, cap.res);
+
+    (req as unknown as Readable).emit('close');
     expect(chatMocks.lastSignal?.aborted).toBe(false);
   });
 });

--- a/api/chat.test.ts
+++ b/api/chat.test.ts
@@ -15,7 +15,9 @@ const chatMocks = vi.hoisted(() => ({
     walletAddress: string | null;
   },
   lastApiKey: '' as string,
+  lastSignal: undefined as AbortSignal | undefined,
   streamChunks: ['data: hello\n\n', 'data: world\n\n'],
+  streamGate: null as Promise<void> | null,
 }));
 
 vi.mock('../server/ratelimit.js', () => ({
@@ -31,12 +33,16 @@ vi.mock('../server/chat.js', () => ({
     (
       args: { messages: Array<{ role: string; content: string }>; walletAddress: string | null },
       apiKey: string,
+      _log: unknown,
+      signal: AbortSignal | undefined,
     ) => {
       chatMocks.lastArgs = args;
       chatMocks.lastApiKey = apiKey;
+      chatMocks.lastSignal = signal;
       const encoder = new TextEncoder();
       return new ReadableStream({
-        start(controller) {
+        async start(controller) {
+          if (chatMocks.streamGate) await chatMocks.streamGate;
           for (const c of chatMocks.streamChunks) controller.enqueue(encoder.encode(c));
           controller.close();
         },
@@ -58,7 +64,16 @@ function makeReq(opts: {
       : typeof opts.body === 'string'
         ? Buffer.from(opts.body)
         : opts.body;
-  const stream = Readable.from(buf.length > 0 ? [buf] : []);
+  let pushed = false;
+  const stream = new Readable({
+    autoDestroy: false,
+    read() {
+      if (pushed) return;
+      pushed = true;
+      if (buf.length > 0) this.push(buf);
+      this.push(null);
+    },
+  });
   Object.assign(stream, {
     method: opts.method ?? 'POST',
     headers: opts.headers ?? {},
@@ -150,7 +165,9 @@ describe('api/chat handler', () => {
     ratelimitMocks.calls.length = 0;
     chatMocks.lastArgs = null;
     chatMocks.lastApiKey = '';
+    chatMocks.lastSignal = undefined;
     chatMocks.streamChunks = ['data: hello\n\n', 'data: world\n\n'];
+    chatMocks.streamGate = null;
   });
 
   afterEach(() => {
@@ -326,5 +343,18 @@ describe('api/chat handler', () => {
     await handler(makeReq({ body: validBody() }), cap.res);
     expect(ratelimitMocks.calls).toHaveLength(1);
     expect(ratelimitMocks.calls[0].identifier).toBe('198.51.100.9');
+  });
+
+  it('passes a non-aborted AbortSignal to createChatStream and signal stays clean on natural completion', async () => {
+    ratelimitMocks.next = {
+      ok: true,
+      limit: 30,
+      remaining: 29,
+      reset: Date.now() + 60_000,
+    };
+    const cap = makeRes();
+    await handler(makeReq({ body: validBody() }), cap.res);
+    expect(chatMocks.lastSignal).toBeInstanceOf(AbortSignal);
+    expect(chatMocks.lastSignal?.aborted).toBe(false);
   });
 });

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -117,6 +117,12 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
   });
 
   const controller = new AbortController();
+  req.on('close', () => {
+    if (!res.writableEnded) {
+      controller.abort();
+      console.log('chat:aborted', { wallet: walletAddress ?? null });
+    }
+  });
 
   const webStream = createChatStream(
     { messages, walletAddress: walletAddress ?? null },

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -116,9 +116,13 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
     'X-Accel-Buffering': 'no',
   });
 
+  const controller = new AbortController();
+
   const webStream = createChatStream(
     { messages, walletAddress: walletAddress ?? null },
     apiKey,
+    undefined,
+    controller.signal,
   );
 
   const nodeStream = Readable.fromWeb(

--- a/docs/superpowers/plans/2026-04-27-d12-server-abort-implementation.md
+++ b/docs/superpowers/plans/2026-04-27-d12-server-abort-implementation.md
@@ -1,0 +1,614 @@
+# D-12 Server-side AbortSignal Propagation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the client aborts an in-flight `/api/chat` request, propagate the abort to the server-side `streamText` call so the LLM provider stops consuming tokens.
+
+**Architecture:** Caller-passes-signal pattern. `api/chat.ts` creates an `AbortController`, listens to `req.on('close')` with a `res.writableEnded` guard, and threads `controller.signal` through a new optional 4th param of `createChatStream` into `streamText({ abortSignal })`. The catch block in `createChatStream` discriminates `AbortError` from real errors and suppresses both `log.error` and `writeEvent({ error })` on abort.
+
+**Tech Stack:** Node.js 24 (Vercel function runtime), AI SDK v6 (`ai@^6.0.168`), Vitest 4.x with `vi.hoisted()` mock state, TypeScript strict mode.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-d12-server-abort-design.md`
+
+**Branch:** `feat/d12-server-abort-propagation`
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `server/chat.ts` | Modify | Add optional `signal?: AbortSignal` 4th param; forward to `streamText({ abortSignal })`; discriminate AbortError in catch block. |
+| `api/chat.ts` | Modify | Create `AbortController` after `writeHead`, register `req.on('close')` listener with `res.writableEnded` guard, pass `controller.signal` to `createChatStream`. |
+| `api/chat.test.ts` | Modify | Extend mock infrastructure (`chatMocks.lastSignal`, `chatMocks.streamGate`) + `makeReq` (`autoDestroy: false`); add Test 1 (signal threaded), Test 2 (abort on close), Test 3 (late close no-op). |
+| `server/chat.test.ts` | Create | New unit-test file for `createChatStream` catch-block discrimination; mocks `ai` + `@ai-sdk/openai`; 2 tests (AbortError suppressed, real error propagated). |
+
+`server/index.ts` (Fastify dev) is **unchanged** — picks up the new optional 4th arg as `undefined`, no-op for dev.
+
+Total diff: ~30 LOC additions in production files + ~120 LOC test additions. Three commits.
+
+---
+
+## Task 1: Thread AbortSignal end-to-end
+
+**Files:**
+- Modify: `api/chat.test.ts` (mock infrastructure + Test 1)
+- Modify: `server/chat.ts` (add signal param + abortSignal in streamText)
+- Modify: `api/chat.ts` (create controller, pass signal)
+
+- [ ] **Step 1: Extend `chatMocks` to capture the signal**
+
+In `api/chat.test.ts`, edit the existing `chatMocks` declaration to add `lastSignal` and `streamGate` fields:
+
+```ts
+const chatMocks = vi.hoisted(() => ({
+  lastArgs: null as null | {
+    messages: Array<{ role: string; content: string }>;
+    walletAddress: string | null;
+  },
+  lastApiKey: '' as string,
+  lastSignal: undefined as AbortSignal | undefined,
+  streamChunks: ['data: hello\n\n', 'data: world\n\n'],
+  streamGate: null as Promise<void> | null,
+}));
+```
+
+- [ ] **Step 2: Update the `createChatStream` mock to capture the signal arg + support gating**
+
+Replace the existing `vi.mock('../server/chat.js', ...)` block in `api/chat.test.ts` with this version. The outer fn stays sync (returns ReadableStream synchronously); only the ReadableStream's `start` is async to await the gate:
+
+```ts
+vi.mock('../server/chat.js', () => ({
+  createChatStream: vi.fn(
+    (
+      args: { messages: Array<{ role: string; content: string }>; walletAddress: string | null },
+      apiKey: string,
+      _log: unknown,
+      signal: AbortSignal | undefined,
+    ) => {
+      chatMocks.lastArgs = args;
+      chatMocks.lastApiKey = apiKey;
+      chatMocks.lastSignal = signal;
+      const encoder = new TextEncoder();
+      return new ReadableStream({
+        async start(controller) {
+          if (chatMocks.streamGate) await chatMocks.streamGate;
+          for (const c of chatMocks.streamChunks) controller.enqueue(encoder.encode(c));
+          controller.close();
+        },
+      });
+    },
+  ),
+}));
+```
+
+- [ ] **Step 3: Update `makeReq` to use `autoDestroy: false`**
+
+The existing `makeReq` uses `Readable.from()` which auto-emits `'close'` after consumption — inverse of real HTTP `IncomingMessage` semantics. Replace `makeReq` in `api/chat.test.ts` with:
+
+```ts
+function makeReq(opts: {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string | Buffer;
+} = {}): IncomingMessage {
+  const buf =
+    opts.body === undefined
+      ? Buffer.alloc(0)
+      : typeof opts.body === 'string'
+        ? Buffer.from(opts.body)
+        : opts.body;
+  let pushed = false;
+  const stream = new Readable({
+    autoDestroy: false,
+    read() {
+      if (pushed) return;
+      pushed = true;
+      if (buf.length > 0) this.push(buf);
+      this.push(null);
+    },
+  });
+  Object.assign(stream, {
+    method: opts.method ?? 'POST',
+    headers: opts.headers ?? {},
+  });
+  return stream as unknown as IncomingMessage;
+}
+```
+
+- [ ] **Step 4: Reset `lastSignal` and `streamGate` in `beforeEach`**
+
+In `api/chat.test.ts`, add to the existing `beforeEach`:
+
+```ts
+beforeEach(() => {
+  process.env.KAMI_OPENROUTER_API_KEY = 'sk-stub-test-key';
+  ratelimitMocks.next = null;
+  ratelimitMocks.identify = '203.0.113.7';
+  ratelimitMocks.calls.length = 0;
+  chatMocks.lastArgs = null;
+  chatMocks.lastApiKey = '';
+  chatMocks.lastSignal = undefined;        // NEW
+  chatMocks.streamChunks = ['data: hello\n\n', 'data: world\n\n'];
+  chatMocks.streamGate = null;             // NEW
+});
+```
+
+- [ ] **Step 5: Write Test 1**
+
+Add this test after the existing `it('passes the identified IP to applyLimit', ...)` test in `api/chat.test.ts`:
+
+```ts
+it('passes a non-aborted AbortSignal to createChatStream and signal stays clean on natural completion', async () => {
+  ratelimitMocks.next = {
+    ok: true,
+    limit: 30,
+    remaining: 29,
+    reset: Date.now() + 60_000,
+  };
+  const cap = makeRes();
+  await handler(makeReq({ body: validBody() }), cap.res);
+  expect(chatMocks.lastSignal).toBeInstanceOf(AbortSignal);
+  expect(chatMocks.lastSignal?.aborted).toBe(false);
+});
+```
+
+- [ ] **Step 6: Run Test 1 — verify FAIL**
+
+```bash
+pnpm exec vitest run api/chat.test.ts -t "passes a non-aborted AbortSignal"
+```
+
+Expected: FAIL — `chatMocks.lastSignal` is `undefined` because `api/chat.ts` does not yet pass a signal to `createChatStream`.
+
+- [ ] **Step 7: Add `signal` param to `createChatStream` and forward to `streamText`**
+
+Edit `server/chat.ts`. Update the `createChatStream` signature:
+
+```ts
+export function createChatStream(
+  input: ChatInput,
+  apiKey: string,
+  log: ChatLogger = consoleLogger,
+  signal?: AbortSignal,
+): ReadableStream<Uint8Array> {
+```
+
+Then update the `streamText` call (currently lines 137-143):
+
+```ts
+const result = streamText({
+  model: openrouter.chat(model),
+  system: SYSTEM_PROMPT + walletContext,
+  messages: input.messages.map((m) => ({ role: m.role, content: m.content })),
+  tools,
+  stopWhen: stepCountIs(maxSteps),
+  abortSignal: signal,
+});
+```
+
+- [ ] **Step 8: Update `api/chat.ts` to create controller and pass signal**
+
+In `api/chat.ts`, modify the `createChatStream` call (currently lines 119-122):
+
+```ts
+const controller = new AbortController();
+
+const webStream = createChatStream(
+  { messages, walletAddress: walletAddress ?? null },
+  apiKey,
+  undefined,
+  controller.signal,
+);
+```
+
+Note: the close listener comes in Task 2. For now the controller is created but never aborted, which is sufficient to make Test 1 pass.
+
+- [ ] **Step 9: Run Test 1 — verify PASS**
+
+```bash
+pnpm exec vitest run api/chat.test.ts -t "passes a non-aborted AbortSignal"
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Run full type-check + test suite**
+
+```bash
+pnpm exec tsc -b && pnpm test:run
+```
+
+Expected: zero TypeScript errors. 130/130 tests passing (was 129; +1 for Test 1).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add server/chat.ts api/chat.ts api/chat.test.ts
+git commit -m "$(cat <<'EOF'
+feat(chat): thread AbortSignal from handler to streamText
+
+Adds optional 4th `signal?: AbortSignal` param to createChatStream and
+forwards it as `abortSignal` to streamText. api/chat.ts creates an
+AbortController and passes its signal. Listener-on-req.close + catch-
+block discrimination ship in follow-up commits.
+EOF
+)"
+```
+
+---
+
+## Task 2: Wire `req.on('close')` to abort the controller
+
+**Files:**
+- Modify: `api/chat.test.ts` (Tests 2 + 3)
+- Modify: `api/chat.ts` (close listener + writableEnded guard)
+
+- [ ] **Step 1: Write Test 2 (abort mid-stream)**
+
+Add to `api/chat.test.ts` after Test 1:
+
+```ts
+it('aborts the AbortSignal when req emits close before res.writableEnded', async () => {
+  let releaseStream: () => void = () => {};
+  chatMocks.streamGate = new Promise<void>((r) => {
+    releaseStream = r;
+  });
+  ratelimitMocks.next = {
+    ok: true,
+    limit: 30,
+    remaining: 29,
+    reset: Date.now() + 60_000,
+  };
+
+  const req = makeReq({ body: validBody() });
+  const cap = makeRes();
+  const handlerDone = handler(req, cap.res);
+
+  await new Promise((r) => setImmediate(r));
+  expect(chatMocks.lastSignal?.aborted).toBe(false);
+
+  (req as unknown as Readable).emit('close');
+  expect(chatMocks.lastSignal?.aborted).toBe(true);
+
+  releaseStream();
+  await handlerDone;
+});
+```
+
+- [ ] **Step 2: Write Test 3 (late close no-op)**
+
+Add to `api/chat.test.ts` after Test 2:
+
+```ts
+it('does not abort the AbortSignal when req emits close after res.writableEnded', async () => {
+  ratelimitMocks.next = {
+    ok: true,
+    limit: 30,
+    remaining: 29,
+    reset: Date.now() + 60_000,
+  };
+  const req = makeReq({ body: validBody() });
+  const cap = makeRes();
+  await handler(req, cap.res);
+
+  (req as unknown as Readable).emit('close');
+  expect(chatMocks.lastSignal?.aborted).toBe(false);
+});
+```
+
+- [ ] **Step 3: Run Tests 2 + 3 — verify Test 2 FAILS, Test 3 PASSES**
+
+```bash
+pnpm exec vitest run api/chat.test.ts -t "AbortSignal when req emits close"
+```
+
+Expected:
+- Test 2: FAIL — no close listener registered yet, `chatMocks.lastSignal?.aborted` is `false` after `req.emit('close')`.
+- Test 3: PASS — same reason; no abort happens, which is the asserted behavior.
+
+(Test 3 trivially passes before the fix; it's a regression guard for after the fix.)
+
+- [ ] **Step 4: Add `req.on('close')` listener with `res.writableEnded` guard**
+
+In `api/chat.ts`, add this block AFTER `res.writeHead(200, { ... })` and BEFORE the `const controller = new AbortController()` line from Task 1. Final shape of that section:
+
+```ts
+res.writeHead(200, {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache, no-transform',
+  Connection: 'keep-alive',
+  'X-Accel-Buffering': 'no',
+});
+
+const controller = new AbortController();
+req.on('close', () => {
+  if (!res.writableEnded) {
+    controller.abort();
+    console.log('chat:aborted', { wallet: walletAddress ?? null });
+  }
+});
+
+const webStream = createChatStream(
+  { messages, walletAddress: walletAddress ?? null },
+  apiKey,
+  undefined,
+  controller.signal,
+);
+```
+
+- [ ] **Step 5: Run Tests 2 + 3 — verify both PASS**
+
+```bash
+pnpm exec vitest run api/chat.test.ts -t "AbortSignal when req emits close"
+```
+
+Expected: both PASS.
+
+- [ ] **Step 6: Run full type-check + test suite**
+
+```bash
+pnpm exec tsc -b && pnpm test:run
+```
+
+Expected: zero TypeScript errors. 132/132 tests passing (was 130; +2 for Tests 2 + 3).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/chat.ts api/chat.test.ts
+git commit -m "$(cat <<'EOF'
+feat(chat): abort LLM call when client disconnects mid-stream
+
+Registers req.on('close') in api/chat.ts with a res.writableEnded
+guard so natural completion does not spuriously abort. Logs
+'chat:aborted' with wallet for ops visibility. Closes the cost-leak
+where streamText kept consuming tokens after the client navigated.
+EOF
+)"
+```
+
+---
+
+## Task 3: Catch-block AbortError discrimination + unit tests
+
+**Files:**
+- Create: `server/chat.test.ts` (new unit-test file for createChatStream catch-block)
+- Modify: `server/chat.ts` (catch-block discrimination)
+
+- [ ] **Step 1: Create `server/chat.test.ts` with the 2 catch-block tests**
+
+Create `server/chat.test.ts`:
+
+```ts
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const aiMocks = vi.hoisted(() => ({
+  fullStreamFactory: null as null | (() => AsyncIterable<unknown>),
+}));
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai');
+  return {
+    ...actual,
+    streamText: vi.fn(() => ({
+      get fullStream() {
+        if (!aiMocks.fullStreamFactory) {
+          throw new Error('test did not configure fullStreamFactory');
+        }
+        return aiMocks.fullStreamFactory();
+      },
+    })),
+  };
+});
+
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: () => ({ chat: () => ({}) }),
+}));
+
+import { createChatStream, type ChatLogger } from './chat';
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(decoder.decode(value));
+  }
+  return chunks.join('');
+}
+
+describe('createChatStream catch-block', () => {
+  let log: ChatLogger;
+
+  beforeEach(() => {
+    aiMocks.fullStreamFactory = null;
+    log = { info: vi.fn(), error: vi.fn() };
+  });
+
+  it('suppresses log.error and stream error event when fullStream throws AbortError', async () => {
+    const abortErr = new Error('aborted');
+    abortErr.name = 'AbortError';
+    aiMocks.fullStreamFactory = async function* () {
+      throw abortErr;
+      // unreachable: ensures generator type is AsyncIterable
+      yield undefined as never;
+    };
+
+    const stream = createChatStream(
+      { messages: [{ role: 'user', content: 'hi' }], walletAddress: null },
+      'sk-stub',
+      log,
+    );
+    const text = await drain(stream);
+
+    expect(log.error).not.toHaveBeenCalled();
+    expect(text).not.toContain('"error"');
+  });
+
+  it('logs error and emits error event when fullStream throws a non-abort error', async () => {
+    aiMocks.fullStreamFactory = async function* () {
+      throw new Error('LLM provider down');
+      yield undefined as never;
+    };
+
+    const stream = createChatStream(
+      { messages: [{ role: 'user', content: 'hi' }], walletAddress: null },
+      'sk-stub',
+      log,
+    );
+    const text = await drain(stream);
+
+    expect(log.error).toHaveBeenCalledTimes(1);
+    expect(text).toContain('"error":"LLM provider down"');
+  });
+});
+```
+
+- [ ] **Step 2: Run new tests — verify the AbortError test FAILS, real-error test PASSES**
+
+```bash
+pnpm exec vitest run server/chat.test.ts
+```
+
+Expected:
+- `suppresses log.error and stream error event when fullStream throws AbortError`: FAIL — current catch block always calls `log.error` and `writeEvent({ error })`.
+- `logs error and emits error event when fullStream throws a non-abort error`: PASS — that's the existing behavior.
+
+- [ ] **Step 3: Add catch-block discrimination in `server/chat.ts`**
+
+Replace the existing catch block in `server/chat.ts` (currently lines 178-181) with this version:
+
+```ts
+} catch (err) {
+  const aborted =
+    signal?.aborted || (err instanceof Error && err.name === 'AbortError');
+  if (!aborted) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    log.error({ err: message }, 'chat stream error');
+    writeEvent({ error: message });
+  }
+} finally {
+  controller.close();
+}
+```
+
+- [ ] **Step 4: Run new tests — verify both PASS**
+
+```bash
+pnpm exec vitest run server/chat.test.ts
+```
+
+Expected: both PASS.
+
+- [ ] **Step 5: Run full type-check + test suite**
+
+```bash
+pnpm exec tsc -b && pnpm test:run
+```
+
+Expected: zero TypeScript errors. 134/134 tests passing across 15 files (was 132; +2 from the new server/chat.test.ts).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/chat.ts server/chat.test.ts
+git commit -m "$(cat <<'EOF'
+feat(chat): suppress log+stream events on AbortError
+
+Catch block in createChatStream now discriminates AbortError (via
+signal.aborted or err.name) from real errors and skips both the
+log.error call and the writeEvent({ error }). Prevents abort noise
+in Vercel error metrics. New server/chat.test.ts unit-tests the
+discrimination on both abort and real-error paths.
+EOF
+)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Final type-check + full suite + build**
+
+```bash
+pnpm exec tsc -b && pnpm test:run && pnpm build
+```
+
+Expected:
+- `pnpm exec tsc -b`: zero errors.
+- `pnpm test:run`: 134/134 across 15 files.
+- `pnpm build`: vite + tsc -b success; bundle size near current ~616 kB main.
+
+- [ ] **Push branch + open PR**
+
+```bash
+git push -u origin feat/d12-server-abort-propagation
+gh pr create --title "feat(chat): D-12 server-side AbortSignal propagation" --body "$(cat <<'EOF'
+## Summary
+
+Closes #13. Sprint 2.1 of Chunk 2 (per `docs/superpowers/specs/2026-04-26-qa-backlog-roadmap-design.md`).
+
+When the client aborts an in-flight `/api/chat` request (user navigates, switches conversation, or deletes the active conversation — all wired in C-3), the TCP socket closes. Before this PR, `streamText` kept running through its `stepCountIs(maxSteps)` budget — paying for tokens the user no longer wants. This PR closes that loop on the server side.
+
+## Changes
+
+- `server/chat.ts`: optional `signal?: AbortSignal` 4th param forwarded to `streamText({ abortSignal })`. Catch block discriminates AbortError (via `signal.aborted || err.name === 'AbortError'`) and suppresses `log.error` + error stream event on abort.
+- `api/chat.ts`: creates `AbortController` after `writeHead`, registers `req.on('close')` listener with `res.writableEnded` guard, passes `controller.signal` to `createChatStream`. Logs `'chat:aborted'` with wallet on real client disconnect.
+- `api/chat.test.ts`: 3 new tests (signal-threaded, abort-on-close, late-close-no-op). Mock infrastructure extends with `lastSignal` capture, `streamGate` for delaying stream completion, and `makeReq` switched to `autoDestroy: false` to mirror real HTTP `IncomingMessage` semantics.
+- `server/chat.test.ts`: new file with 2 unit tests covering the catch-block discrimination on both abort and real-error paths.
+- `server/index.ts` (Fastify dev) unchanged — picks up the new optional 4th arg as `undefined`. Per scope (variant b skipped); dev pays no token costs.
+
+## Test plan
+
+- [x] `pnpm exec tsc -b` clean
+- [x] `pnpm test:run` — 134/134 passing across 15 files
+- [x] `pnpm build` succeeds with normal bundle size
+- [ ] Manual smoke (post-merge prod): open two browser tabs at https://kami.rectorspace.com, send a yield-finder message in tab A, switch to tab B before stream completes, verify Vercel function logs show `chat:aborted` and OpenRouter dashboard shows the call was cut short
+EOF
+)"
+```
+
+- [ ] **Wait for CI + merge with `--merge` (keep branches)**
+
+```bash
+gh pr checks --watch
+gh pr merge --merge
+```
+
+- [ ] **Production smoke + close umbrella checkbox**
+
+After Vercel auto-deploys main:
+
+```bash
+# Verify deploy
+curl -sS https://kami.rectorspace.com/api/rpc \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' -D - | head -5
+
+# Then run the manual smoke in a real browser, check Vercel function logs for chat:aborted
+gh issue list --label qa-2026-04-26 --state open --limit 30  # expect 24 open (was 25)
+gh issue view 3  # ensure #13 ticked in umbrella
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- ✅ Architecture diagram → reflected in code changes across Tasks 1, 2, 3.
+- ✅ Code change to `server/chat.ts` (signature + abortSignal + catch) → Tasks 1 + 3.
+- ✅ Code change to `api/chat.ts` (controller + close listener + signal pass) → Tasks 1 + 2.
+- ✅ Mock infrastructure changes → Task 1, Step 1-4.
+- ✅ Test 1 (signal-threaded) → Task 1, Step 5-6 + 9.
+- ✅ Test 2 (abort-on-close) → Task 2, Step 1 + 3 + 5.
+- ✅ Test 3 (late-close no-op) → Task 2, Step 2 + 3 + 5.
+- ✅ Catch-block discrimination + unit tests → Task 3 (server/chat.test.ts).
+- ✅ Acceptance criteria checklist → Final verification section.
+- ✅ `server/index.ts` (Fastify dev) unchanged per scope — explicitly noted in File Structure section.
+
+**Placeholder scan:** No TBD/TODO/"add appropriate handling" / "similar to Task N" / etc. All steps have actual code.
+
+**Type consistency:** `chatMocks.lastSignal: AbortSignal | undefined` declared in Task 1 Step 1, used in Task 1 Step 5 (`expect(chatMocks.lastSignal).toBeInstanceOf(AbortSignal)`), Task 2 Step 1 (`chatMocks.lastSignal?.aborted`), Task 2 Step 2. Consistent. `signal?: AbortSignal` 4th param in `createChatStream` is consistent across Task 1 Step 7 (declaration), Task 1 Step 8 (api/chat.ts call site), Task 3 Step 3 (catch-block usage). `streamGate: Promise<void> | null` declared in Task 1 Step 1, reset in Task 1 Step 4, consumed in Task 2 Step 1.

--- a/docs/superpowers/specs/2026-04-27-d12-server-abort-design.md
+++ b/docs/superpowers/specs/2026-04-27-d12-server-abort-design.md
@@ -22,6 +22,7 @@ C-3 closed the loop on the client side (fetch aborts, ghost writes prevented). D
 - Discriminate AbortError from real errors in the existing catch block; skip the error-log path on abort.
 - Info-log on abort (`console.log('chat:aborted', { wallet })`) for ops visibility.
 - Add 3 tests in `api/chat.test.ts` covering signal threading + abort-on-close + late-close-no-op.
+- Add new `server/chat.test.ts` with 2 unit tests for the catch-block discrimination on both abort and real-error paths (catch block cannot be tested through `api/chat.test.ts` because that file mocks `createChatStream` away).
 
 **Out of scope** (skipped variants and non-goals):
 - Fastify dev server (`server/index.ts`) abort wiring — variant `(b)` skipped. Dev pays no token costs.
@@ -247,12 +248,31 @@ it('does not abort the AbortSignal when req emits close after res.writableEnded'
 });
 ```
 
+### Catch-block coverage — new `server/chat.test.ts`
+
+The catch-block discrimination (`signal?.aborted || err.name === 'AbortError'`) is new code in `server/chat.ts`. It cannot be tested through `api/chat.test.ts` because that file mocks `createChatStream` away. So a new unit-test file `server/chat.test.ts` is added with 2 tests:
+
+```ts
+// server/chat.test.ts (new file)
+//
+// Mocks `ai` and `@ai-sdk/openai`; uses an `aiMocks.fullStreamFactory`
+// hoisted shared state to inject either an AbortError or a real error
+// into the streamText fullStream. Drains the returned ReadableStream
+// and asserts on log.error invocation count + presence of "error"
+// in the streamed body.
+//
+// 1. 'suppresses log.error and stream error event when fullStream throws AbortError'
+// 2. 'logs error and emits error event when fullStream throws a non-abort error'
+```
+
 ### Coverage delta
 
 | Suite | Before | After |
 |---|---|---|
-| Total tests | 129 | 132 |
+| Total tests | 129 | 134 |
+| Test files | 14 | 15 |
 | `api/chat.test.ts` tests | 14 | 17 |
+| `server/chat.test.ts` tests | 0 | 2 |
 
 ## Edge cases
 
@@ -278,10 +298,11 @@ it('does not abort the AbortSignal when req emits close after res.writableEnded'
 ## Acceptance criteria
 
 - [ ] `pnpm exec tsc -b` clean.
-- [ ] `pnpm test:run` — 132/132 passing.
+- [ ] `pnpm test:run` — 134/134 passing across 15 files.
 - [ ] Test 1 (signal-threaded) passes.
 - [ ] Test 2 (abort-on-close) passes.
 - [ ] Test 3 (late-close no-op) passes.
+- [ ] `server/chat.test.ts` — both catch-block discrimination tests pass.
 - [ ] Manual smoke: production deploy, open two browser tabs, send a message in tab A, switch to tab B before the stream completes — verify Vercel function logs show `chat:aborted` and OpenRouter dashboard shows the request was cut short (no full stepCountIs budget consumed).
 - [ ] Issue #13 closed by the merge commit (via `Closes #13` in PR body).
 

--- a/docs/superpowers/specs/2026-04-27-d12-server-abort-design.md
+++ b/docs/superpowers/specs/2026-04-27-d12-server-abort-design.md
@@ -1,0 +1,298 @@
+# D-12 — Server-side AbortSignal propagation
+
+**Date:** 2026-04-27
+**Issue:** [#13 — Propagate AbortSignal through to server-side streamText](https://github.com/RECTOR-LABS/kami/issues/13)
+**Priority:** P1 (`qa-2026-04-26`)
+**Sprint:** 2.1 (Chunk 2 — Test/Abort/Safety Extensions)
+**Estimate:** 2-4h
+**Branch:** `feat/d12-server-abort-propagation`
+
+---
+
+## Problem
+
+When the client aborts an in-flight `/api/chat` request (user navigates, switches conversation, or deletes the active conversation — all wired in C-3 / D-4), the TCP socket closes and `nodeStream.pipe(res)` is destroyed. But the upstream `streamText` call inside `createChatStream` keeps running through its `stepCountIs(maxSteps)` budget — the LLM provider continues consuming tokens that the user no longer wants.
+
+C-3 closed the loop on the client side (fetch aborts, ghost writes prevented). D-12 closes the loop on the server side: when the client disconnects, the LLM call cancels.
+
+## Scope
+
+**In scope** (variant `(a)+(c)` per brainstorm):
+- Thread `AbortSignal` from `api/chat.ts` (controller created in handler, aborted on `req.on('close')`) → `createChatStream` (new optional 4th `signal` arg) → `streamText({ abortSignal })`.
+- Discriminate AbortError from real errors in the existing catch block; skip the error-log path on abort.
+- Info-log on abort (`console.log('chat:aborted', { wallet })`) for ops visibility.
+- Add 3 tests in `api/chat.test.ts` covering signal threading + abort-on-close + late-close-no-op.
+
+**Out of scope** (skipped variants and non-goals):
+- Fastify dev server (`server/index.ts`) abort wiring — variant `(b)` skipped. Dev pays no token costs.
+- Cancelling in-flight Solana RPC tool executions — tools are <1s; LLM call is the 90% cost win.
+- Adding `timeout` to `streamText` — Vercel function `maxDuration: 60` already caps wall-clock.
+- Structured-log adapter for the abort log line — D-14 handles structured logging globally.
+- Client-side test expansion for abort behavior — that's Sprint 2.2 (D-11).
+
+## Architecture
+
+End-to-end signal propagation:
+
+```
+useChat.ts (client)              api/chat.ts (handler)         server/chat.ts (createChatStream)
+─────────────────                ────────────────────          ──────────────────────────────────
+fetch({ signal })   ──────►  TCP socket close
+                             req.on('close', () => {
+                               if (!res.writableEnded) {
+                                 controller.abort()  ──────►  signal.aborted = true
+                                 console.log('chat:aborted',
+                                             { wallet })
+                               }
+                             })
+                             createChatStream(..., signal)  ─►  streamText({ abortSignal: signal })
+                                                                  for await throws AbortError
+                                                                  catch block detects abort:
+                                                                  - skips log.error
+                                                                  - skips writeEvent({ error })
+                                                                  - controller.close() in finally
+```
+
+### Key design decisions
+
+1. **`AbortController` lives in the handler (`api/chat.ts`)**, not in `createChatStream`. Caller-passes-signal pattern — testable, composable, no leaky abstraction.
+2. **`signal?: AbortSignal` is optional** on `createChatStream` — preserves backward-compat for `server/index.ts` (Fastify dev) and existing test mocks. No breaking changes in the same commit.
+3. **`res.writableEnded` guard** on `req.on('close')` — distinguishes natural-completion close (no abort needed) from client-disconnect close (real abort). This is the canonical Node.js check.
+4. **Both abort-detection checks** in the catch block: `signal?.aborted || err.name === 'AbortError'`. Belt-and-suspenders against AI SDK wrapping the error.
+
+## Code changes
+
+Three files touched. Total diff target: ~30 LOC additions across two production files + ~70 LOC test additions.
+
+### `server/chat.ts`
+
+Three surgical changes — signature widening, signal forwarding, abort discrimination in catch:
+
+```diff
+ export function createChatStream(
+   input: ChatInput,
+   apiKey: string,
+-  log: ChatLogger = consoleLogger
++  log: ChatLogger = consoleLogger,
++  signal?: AbortSignal,
+ ): ReadableStream<Uint8Array> {
+   // ... unchanged setup ...
+
+   const result = streamText({
+     model: openrouter.chat(model),
+     system: SYSTEM_PROMPT + walletContext,
+     messages: input.messages.map((m) => ({ role: m.role, content: m.content })),
+     tools,
+     stopWhen: stepCountIs(maxSteps),
++    abortSignal: signal,
+   });
+
+   // ... unchanged for-await loop ...
+
+   } catch (err) {
++    const aborted =
++      signal?.aborted || (err instanceof Error && err.name === 'AbortError');
++    if (!aborted) {
+       const message = err instanceof Error ? err.message : 'Unknown error';
+       log.error({ err: message }, 'chat stream error');
+       writeEvent({ error: message });
++    }
+   } finally {
+     controller.close();
+   }
+```
+
+### `api/chat.ts`
+
+Add controller + close listener after `writeHead`. Pass signal as 4th arg:
+
+```diff
+   res.writeHead(200, { ... });
+
++  const controller = new AbortController();
++  req.on('close', () => {
++    if (!res.writableEnded) {
++      controller.abort();
++      console.log('chat:aborted', { wallet: walletAddress ?? null });
++    }
++  });
++
+   const webStream = createChatStream(
+     { messages, walletAddress: walletAddress ?? null },
+     apiKey,
++    undefined,
++    controller.signal,
+   );
+```
+
+### `server/index.ts` (Fastify dev)
+
+**Unchanged.** Picks up the optional 4th arg as `undefined` — no-op for dev.
+
+### `api/chat.test.ts`
+
+Three additions — see Testing section below.
+
+## Testing
+
+Three new tests added to the existing `describe('api/chat handler', ...)` block. Mock infrastructure extends to support signal capture and stream gating.
+
+### Mock infrastructure changes
+
+```ts
+// chatMocks (vi.hoisted) gains two fields:
+const chatMocks = vi.hoisted(() => ({
+  // ... existing fields
+  lastSignal: undefined as AbortSignal | undefined,    // NEW: capture 4th arg
+  streamGate: null as Promise<void> | null,            // NEW: delay stream completion
+}));
+
+// Mock impl gains signal capture + optional gating. Outer fn stays sync
+// (createChatStream returns ReadableStream synchronously); only the
+// ReadableStream's `start` needs to be async to await the gate.
+vi.mock('../server/chat.js', () => ({
+  createChatStream: vi.fn(
+    (
+      args: ...,
+      apiKey: string,
+      _log: unknown,
+      signal: AbortSignal | undefined,
+    ) => {
+      chatMocks.lastArgs = args;
+      chatMocks.lastApiKey = apiKey;
+      chatMocks.lastSignal = signal;
+      const encoder = new TextEncoder();
+      return new ReadableStream({
+        async start(controller) {
+          if (chatMocks.streamGate) await chatMocks.streamGate;
+          for (const c of chatMocks.streamChunks) controller.enqueue(encoder.encode(c));
+          controller.close();
+        },
+      });
+    },
+  ),
+}));
+```
+
+### `makeReq` change
+
+The current mock uses `Readable.from()` which auto-emits `'close'` after body consumption — this is the inverse of real HTTP `IncomingMessage` semantics, where `'close'` only fires on TCP socket disconnect. Switch to a manually-constructed Readable with `autoDestroy: false`:
+
+```ts
+function makeReq(opts: ...): IncomingMessage {
+  const buf = ...;
+  let pushed = false;
+  const stream = new Readable({
+    autoDestroy: false,
+    read() {
+      if (pushed) return;
+      pushed = true;
+      if (buf.length > 0) this.push(buf);
+      this.push(null);
+    },
+  });
+  Object.assign(stream, { method: opts.method ?? 'POST', headers: opts.headers ?? {} });
+  return stream as unknown as IncomingMessage;
+}
+```
+
+This lets tests control when `'close'` fires (manually via `stream.emit('close')`) instead of inheriting auto-close timing from `Readable.from()`.
+
+### Test 1 — signal threaded, not aborted on natural completion
+
+```ts
+it('passes a non-aborted AbortSignal to createChatStream and signal stays clean on natural completion', async () => {
+  ratelimitMocks.next = { ok: true, limit: 30, remaining: 29, reset: Date.now() + 60_000 };
+  const cap = makeRes();
+  await handler(makeReq({ body: validBody() }), cap.res);
+  expect(chatMocks.lastSignal).toBeInstanceOf(AbortSignal);
+  expect(chatMocks.lastSignal?.aborted).toBe(false);
+});
+```
+
+### Test 2 — req close mid-stream aborts the signal
+
+```ts
+it('aborts the AbortSignal when req emits close before res.writableEnded', async () => {
+  let releaseStream: () => void = () => {};
+  chatMocks.streamGate = new Promise<void>((r) => { releaseStream = r; });
+  ratelimitMocks.next = { ok: true, limit: 30, remaining: 29, reset: Date.now() + 60_000 };
+
+  const req = makeReq({ body: validBody() });
+  const cap = makeRes();
+  const handlerDone = handler(req, cap.res);
+
+  await new Promise((r) => setImmediate(r));  // let handler enter the pipe-await
+  expect(chatMocks.lastSignal?.aborted).toBe(false);
+
+  (req as unknown as Readable).emit('close');
+  expect(chatMocks.lastSignal?.aborted).toBe(true);
+
+  releaseStream();
+  await handlerDone;
+});
+```
+
+### Test 3 — late close after natural completion is a no-op
+
+```ts
+it('does not abort the AbortSignal when req emits close after res.writableEnded', async () => {
+  ratelimitMocks.next = { ok: true, limit: 30, remaining: 29, reset: Date.now() + 60_000 };
+  const req = makeReq({ body: validBody() });
+  const cap = makeRes();
+  await handler(req, cap.res);  // natural completion, sets writableEnded
+
+  (req as unknown as Readable).emit('close');
+  expect(chatMocks.lastSignal?.aborted).toBe(false);
+});
+```
+
+### Coverage delta
+
+| Suite | Before | After |
+|---|---|---|
+| Total tests | 129 | 132 |
+| `api/chat.test.ts` tests | 14 | 17 |
+
+## Edge cases
+
+| Edge case | Handling |
+|---|---|
+| AbortError thrown by `result.fullStream` for-await | Catch block discriminates with `signal?.aborted \|\| err.name === 'AbortError'`. Skips both `log.error` AND `writeEvent({ error })`. |
+| Listener leak after stream completes | Not a concern — `IncomingMessage` is GC'd with the request lifecycle. Listener has no external references. |
+| Race: `res.end()` fires between our check and `controller.abort()` | Node event loop is single-threaded. Check + abort are atomic relative to other handlers — no torn read. |
+| Real HTTP `IncomingMessage` vs test mock `Readable.from()` | Real `req.on('close')` only fires on TCP socket close; `Readable.from()` auto-emits close after consumption. Test infra fix: `autoDestroy: false`. |
+| Multiple listeners on `req 'close'` | None — Node core doesn't add others on `IncomingMessage`. Our single listener owns it. |
+| Tools-in-flight at abort time | Resolve naturally. The abort cancels the LLM provider call (via AI SDK's `abortSignal`), not the in-flight tool's Solana RPC requests. |
+
+## Non-goals — explicitly deferred
+
+| Item | Where it goes |
+|---|---|
+| Cancel in-flight Solana RPC tool calls | Future sprint if it becomes a real cost concern. Today's tools are <1s each. |
+| `timeout` option on `streamText` | YAGNI. Vercel `maxDuration: 60` already caps wall-clock. |
+| Wire abort in `server/index.ts` (Fastify dev) | Variant `(b)` deferred. Optional polish; dev pays no token costs. |
+| Structured-log adapter for `chat:aborted` | D-14 (P2) — global structured-log refactor handles all current `console.log` call sites at once. |
+| Client-side test expansion (abort behavior in `useChat.test.ts`) | Sprint 2.2 (D-11). D-12 is server-side only. |
+
+## Acceptance criteria
+
+- [ ] `pnpm exec tsc -b` clean.
+- [ ] `pnpm test:run` — 132/132 passing.
+- [ ] Test 1 (signal-threaded) passes.
+- [ ] Test 2 (abort-on-close) passes.
+- [ ] Test 3 (late-close no-op) passes.
+- [ ] Manual smoke: production deploy, open two browser tabs, send a message in tab A, switch to tab B before the stream completes — verify Vercel function logs show `chat:aborted` and OpenRouter dashboard shows the request was cut short (no full stepCountIs budget consumed).
+- [ ] Issue #13 closed by the merge commit (via `Closes #13` in PR body).
+
+## Risks
+
+- **Test 2 race-condition fragility:** `setImmediate` to allow the handler to enter the pipe-await is a heuristic. If the handler reorders work, the test may flake. Mitigation: the test timing is brittle by nature; if it flakes, switch to a polling check (`while (!chatMocks.lastSignal) await tick()`).
+- **AI SDK v6 abort semantics undocumented for `streamText`:** the `abortSignal` field in `streamText` options is typed but the runtime behavior under abort (does the for-await throw immediately? does it gracefully end?) needs to be verified during implementation. Fallback: if AI SDK swallows abort, we still get the cost win (provider connection closed), just without a clean throw — the catch block handles either.
+- **`res.writableEnded` not set in time:** if the pipe completes but res isn't yet "ended" by the time req.close fires, our guard fails and we spuriously abort. Mitigation: `res.writableEnded` is set synchronously by `res.end()` per Node docs — should be reliable. If we see flakes, add a `completed` flag that's set after the pipe-end Promise resolves.
+
+## Acceptance — done when
+
+> "Would this survive a security audit?" Yes — no new attack surface; signal flow is purely internal cleanup.
+> "Would I deploy this to mainnet tonight?" Yes — backward-compat preserved, tests cover both happy and abort paths.
+> "Will the next developer understand why I made these choices?" The 4-arg signature is documented in this spec and the optional-signal pattern is the textbook Node abort idiom.

--- a/server/chat.test.ts
+++ b/server/chat.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const aiMocks = vi.hoisted(() => ({
+  fullStreamFactory: null as null | (() => AsyncIterable<unknown>),
+}));
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai');
+  return {
+    ...actual,
+    streamText: vi.fn(() => ({
+      get fullStream() {
+        if (!aiMocks.fullStreamFactory) {
+          throw new Error('test did not configure fullStreamFactory');
+        }
+        return aiMocks.fullStreamFactory();
+      },
+    })),
+  };
+});
+
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: () => ({ chat: () => ({}) }),
+}));
+
+import { createChatStream, type ChatLogger } from './chat';
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(decoder.decode(value));
+  }
+  return chunks.join('');
+}
+
+describe('createChatStream catch-block', () => {
+  let log: ChatLogger;
+
+  beforeEach(() => {
+    aiMocks.fullStreamFactory = null;
+    log = { info: vi.fn(), error: vi.fn() };
+  });
+
+  it('suppresses log.error and stream error event when fullStream throws AbortError', async () => {
+    const abortErr = new Error('aborted');
+    abortErr.name = 'AbortError';
+    aiMocks.fullStreamFactory = async function* () {
+      throw abortErr;
+      // unreachable: ensures generator type is AsyncIterable
+      yield undefined as never;
+    };
+
+    const stream = createChatStream(
+      { messages: [{ role: 'user', content: 'hi' }], walletAddress: null },
+      'sk-stub',
+      log,
+    );
+    const text = await drain(stream);
+
+    expect(log.error).not.toHaveBeenCalled();
+    expect(text).not.toContain('"error"');
+  });
+
+  it('logs error and emits error event when fullStream throws a non-abort error', async () => {
+    aiMocks.fullStreamFactory = async function* () {
+      throw new Error('LLM provider down');
+      yield undefined as never;
+    };
+
+    const stream = createChatStream(
+      { messages: [{ role: 'user', content: 'hi' }], walletAddress: null },
+      'sk-stub',
+      log,
+    );
+    const text = await drain(stream);
+
+    expect(log.error).toHaveBeenCalledTimes(1);
+    expect(text).toContain('"error":"LLM provider down"');
+  });
+});

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -109,7 +109,8 @@ function buildTools(ctx: ToolContext, log: ChatLogger) {
 export function createChatStream(
   input: ChatInput,
   apiKey: string,
-  log: ChatLogger = consoleLogger
+  log: ChatLogger = consoleLogger,
+  signal?: AbortSignal,
 ): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   const model = process.env.KAMI_MODEL || 'anthropic/claude-sonnet-4.6';
@@ -140,6 +141,7 @@ export function createChatStream(
           messages: input.messages.map((m) => ({ role: m.role, content: m.content })),
           tools,
           stopWhen: stepCountIs(maxSteps),
+          abortSignal: signal,
         });
 
         for await (const part of result.fullStream) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -178,9 +178,13 @@ export function createChatStream(
 
         controller.enqueue(encoder.encode('data: [DONE]\n\n'));
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error';
-        log.error({ err: message }, 'chat stream error');
-        writeEvent({ error: message });
+        const aborted =
+          signal?.aborted || (err instanceof Error && err.name === 'AbortError');
+        if (!aborted) {
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          log.error({ err: message }, 'chat stream error');
+          writeEvent({ error: message });
+        }
       } finally {
         controller.close();
       }


### PR DESCRIPTION
## Summary

Closes #13. Sprint 2.1 of Chunk 2 (per `docs/superpowers/specs/2026-04-26-qa-backlog-roadmap-design.md`).

When the client aborts an in-flight `/api/chat` request (user navigates, switches conversation, or deletes the active conversation — already wired in C-3), the TCP socket closes. Before this PR, `streamText` kept running through its `stepCountIs(maxSteps)` budget — paying for tokens the user no longer wanted. This PR closes that loop on the server side.

## Changes

**`server/chat.ts`** (Tasks 1 + 3)
- Optional `signal?: AbortSignal` 4th param forwarded to `streamText({ abortSignal })`.
- Catch block discriminates `AbortError` (via `signal?.aborted || err.name === 'AbortError'`) and suppresses both `log.error` and the SSE error event on abort.

**`api/chat.ts`** (Task 2)
- Creates `AbortController` after `writeHead`.
- Registers `req.on('close')` listener with `res.writableEnded` guard (distinguishes natural completion from real disconnect).
- Logs `'chat:aborted'` with wallet on real client disconnect.
- Passes `controller.signal` as 4th arg to `createChatStream`.

**`api/chat.test.ts`**
- 3 new tests: signal-threaded, abort-on-close, late-close-no-op (129 → 132).
- Mock infrastructure: `chatMocks.lastSignal` capture, `chatMocks.streamGate` for delaying stream completion, `makeReq` switched to `autoDestroy: false` to mirror real HTTP `IncomingMessage` semantics, `writableEnded` getter on `makeRes()` to work around `vite-plugin-node-polyfills` swap of `node:stream` → `readable-stream@3`.

**`server/chat.test.ts`** (new file)
- 2 unit tests covering the catch-block discrimination on both abort and real-error paths (132 → 134).

**`server/index.ts`** (Fastify dev) — unchanged. Picks up the new optional 4th arg as `undefined`. Per scope (variant b skipped); dev pays no token costs.

## Spec + plan

- Spec: `docs/superpowers/specs/2026-04-27-d12-server-abort-design.md`
- Plan: `docs/superpowers/plans/2026-04-27-d12-server-abort-implementation.md`

## Test plan

- [x] \`pnpm exec tsc -b\` clean
- [x] \`pnpm test:run\` — 134/134 passing across 15 files
- [x] Per-task spec compliance review ✅ (Task 1, 2, 3)
- [x] Per-task code quality review ✅ (Task 1, 2, 3)
- [x] Final cluster review verdict — **SHIP IT** (0 critical, 0 important, 6 minor info-only)
- [ ] Manual smoke (post-merge prod): open two browser tabs at https://kami.rectorspace.com, send a yield-finder message in tab A, switch to tab B before stream completes, verify Vercel function logs show \`chat:aborted\` and OpenRouter dashboard shows the call was cut short