### PR TITLE
feat(chat): D-13 oracle-staleness gate on findYield/getPortfolio

### DIFF
--- a/docs/superpowers/plans/2026-04-27-d13-oracle-staleness-implementation.md
+++ b/docs/superpowers/plans/2026-04-27-d13-oracle-staleness-implementation.md
@@ -1,0 +1,422 @@
+# D-13 Oracle-Staleness Gate — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface oracle freshness on `findYield` and `getPortfolio` tool outputs, and instruct the LLM to flag stale rows with ⚠️ in markdown tables.
+
+**Architecture:** A pure helper `computeStaleness(reserve, currentSlot)` derives `{ priceStale, slotsSinceRefresh }` from `reserve.state.lastUpdate.slot` against a 150-slot threshold (~60s). Both `YieldOpportunity` and `PortfolioPosition` gain the two fields; both call sites spread the helper output into their row objects. The LLM system prompt picks up a one-rule update.
+
+**Tech Stack:** Node.js 24 (Vercel Function runtime), `@kamino-finance/klend-sdk` 7.3 on `@solana/kit` v2, `bn.js` for `BN` slot arithmetic, Vitest 4.x for unit tests.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-d13-oracle-staleness-design.md`
+
+**Branch:** `feat/d13-oracle-staleness-gate`
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `server/tools/kamino.ts` | Modify | Add `STALENESS_THRESHOLD_SLOTS` constant + `computeStaleness` helper (exported); extend `YieldOpportunity` and `PortfolioPosition` interfaces with `priceStale: boolean` + `slotsSinceRefresh: number`; spread helper output at the `findYield` and `mapPositions` call sites. |
+| `server/prompt.ts` | Modify | Add one rule line under "Numbers from tools are live mainnet values" instructing the LLM to prepend ⚠️ to stale rows in markdown tables and add a one-sentence footer. |
+| `server/tools/kamino.test.ts` | Create | New unit-test file for the `kamino.ts` module. 4 tests covering `computeStaleness` (fresh, stale, threshold-boundary, clock-skew clamp). First test file for `kamino.ts` (currently the un-mocked surface per `CLAUDE.md`). |
+
+`server/index.ts` (Fastify dev) and `api/chat.ts` are **unchanged**. Total diff: ~25 LOC additions in production files + ~50 LOC test additions. Three commits.
+
+---
+
+## Task 1: TDD the helper — `computeStaleness`
+
+**Files:**
+- Create: `server/tools/kamino.test.ts` (new file)
+- Modify: `server/tools/kamino.ts` (add constant + exported helper)
+
+- [ ] **Step 1: Create `server/tools/kamino.test.ts` with 4 unit tests**
+
+Create `server/tools/kamino.test.ts`:
+
+```ts
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import BN from 'bn.js';
+import { computeStaleness } from './kamino';
+import type { KaminoReserve } from '@kamino-finance/klend-sdk';
+
+const BASELINE_SLOT = 1000n;
+
+function reserveAt(slot: number): KaminoReserve {
+  return {
+    state: { lastUpdate: { slot: new BN(slot) } },
+  } as unknown as KaminoReserve;
+}
+
+describe('computeStaleness', () => {
+  it('returns priceStale=false for a fresh reserve (50 slots old)', () => {
+    const r = reserveAt(950);
+    expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
+      priceStale: false,
+      slotsSinceRefresh: 50,
+    });
+  });
+
+  it('returns priceStale=true for a stale reserve (200 slots old)', () => {
+    const r = reserveAt(800);
+    expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
+      priceStale: true,
+      slotsSinceRefresh: 200,
+    });
+  });
+
+  it('returns priceStale=false at the exact threshold (150 slots old) — uses > not >=', () => {
+    const r = reserveAt(850);
+    expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
+      priceStale: false,
+      slotsSinceRefresh: 150,
+    });
+  });
+
+  it('clamps negative slot diffs to 0 (RPC clock skew defense)', () => {
+    const r = reserveAt(1010);
+    expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
+      priceStale: false,
+      slotsSinceRefresh: 0,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run new tests — verify FAIL**
+
+```bash
+pnpm exec vitest run server/tools/kamino.test.ts
+```
+
+Expected: import error or 4 failures because `computeStaleness` is not yet exported from `./kamino`.
+
+- [ ] **Step 3: Add the constant + helper in `server/tools/kamino.ts`**
+
+In `server/tools/kamino.ts`, find the existing `toNumber` helper (around line 79). Add the constant + `computeStaleness` helper IMMEDIATELY AFTER `toNumber`. The intended insertion point sits between `toNumber` and the `mapPositions` function. Add:
+
+```ts
+const STALENESS_THRESHOLD_SLOTS = 150;  // ~60s @ ~400ms/slot — Solana DeFi convention (Pyth, Switchboard)
+
+export function computeStaleness(
+  reserve: KaminoReserve,
+  currentSlot: bigint,
+): { priceStale: boolean; slotsSinceRefresh: number } {
+  const lastSlot = reserve.state.lastUpdate.slot.toNumber();
+  const slotsSinceRefresh = Math.max(0, Number(currentSlot) - lastSlot);
+  return {
+    priceStale: slotsSinceRefresh > STALENESS_THRESHOLD_SLOTS,
+    slotsSinceRefresh,
+  };
+}
+```
+
+Notes:
+- `KaminoReserve` is already imported elsewhere in the file (used by `mapPositions`); no new import needed.
+- `BN` is part of `reserve.state.lastUpdate.slot` already; no new import needed in production code.
+
+- [ ] **Step 4: Run new tests — verify PASS**
+
+```bash
+pnpm exec vitest run server/tools/kamino.test.ts
+```
+
+Expected: 4/4 PASS.
+
+- [ ] **Step 5: Run full type-check + test suite**
+
+```bash
+pnpm exec tsc -b && pnpm test:run
+```
+
+Expected: zero TypeScript errors. **138/138 tests passing across 16 files** (was 134; +4 from the new file).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tools/kamino.ts server/tools/kamino.test.ts
+git commit -m "$(cat <<'EOF'
+feat(kamino): add computeStaleness helper
+
+Pure helper derives { priceStale, slotsSinceRefresh } from
+reserve.state.lastUpdate.slot vs currentSlot using a 150-slot threshold
+(~60s, Solana DeFi convention). Negative slot diffs clamped to 0
+(RPC clock-skew defense). 4 unit tests in new server/tools/kamino.test.ts.
+
+The handoff flagged reserve.getReserveOracleStatus() as unverified —
+verified via klend-sdk source: that method does NOT exist; slot-age is
+the canonical signal.
+EOF
+)"
+```
+
+---
+
+## Task 2: Surface staleness on `findYield` + `getPortfolio` rows
+
+**Files:**
+- Modify: `server/tools/kamino.ts` (extend interfaces + spread helper output at 2 call sites)
+
+- [ ] **Step 1: Extend `YieldOpportunity` interface**
+
+In `server/tools/kamino.ts`, find the existing `YieldOpportunity` interface (around line 201). Add two new fields after `marketPriceUsd`:
+
+```ts
+export interface YieldOpportunity {
+  symbol: string;
+  mint: string;
+  reserve: string;
+  side: 'supply' | 'borrow';
+  apyPercent: number;
+  ltvRatio: number;
+  liquidationLtv: number;
+  utilizationPercent: number;
+  marketPriceUsd: number;
+  priceStale: boolean;
+  slotsSinceRefresh: number;
+}
+```
+
+- [ ] **Step 2: Extend `PortfolioPosition` interface**
+
+In `server/tools/kamino.ts`, find the existing `PortfolioPosition` interface (around line 38). Add two new fields after `apyPercent`:
+
+```ts
+export interface PortfolioPosition {
+  symbol: string;
+  mint: string;
+  reserve: string;
+  amount: number;
+  valueUsd: number;
+  apyPercent: number;
+  priceStale: boolean;
+  slotsSinceRefresh: number;
+}
+```
+
+- [ ] **Step 3: Spread `computeStaleness` into the `findYield` row push**
+
+In `server/tools/kamino.ts`, find the existing `opportunities.push({...})` call inside `findYield` (around lines 246-256). Replace that push with:
+
+```ts
+opportunities.push({
+  symbol,
+  mint: reserve.stats.mintAddress,
+  reserve: reserve.address,
+  side,
+  apyPercent: apy * 100,
+  ltvRatio: reserve.stats.loanToValue,
+  liquidationLtv: reserve.stats.liquidationThreshold,
+  utilizationPercent: computeUtilizationPercent(reserve),
+  marketPriceUsd: toNumber(reserve.getOracleMarketPrice()),
+  ...computeStaleness(reserve, currentSlot),
+});
+```
+
+- [ ] **Step 4: Spread `computeStaleness` into the `mapPositions` row push (with reserve-undefined guard)**
+
+In `server/tools/kamino.ts`, find the existing `out.push({...})` call inside `mapPositions` (around lines 99-106). The existing handler already guards `reserve: KaminoReserve | undefined` because some obligations may reference reserves that have been removed. Add a ternary fallback for the missing-reserve case. Replace the for-of body:
+
+```ts
+for (const [, pos] of positions) {
+  const reserve: KaminoReserve | undefined = market.getReserveByAddress(pos.reserveAddress);
+  const symbol = reserve?.getTokenSymbol() ?? 'UNKNOWN';
+  const tokenAmount = pos.amount.div(pos.mintFactor);
+  const apy = reserve
+    ? kind === 'supply'
+      ? reserve.totalSupplyAPY(currentSlot)
+      : reserve.totalBorrowAPY(currentSlot)
+    : 0;
+  const staleness = reserve
+    ? computeStaleness(reserve, currentSlot)
+    : { priceStale: false, slotsSinceRefresh: 0 };
+  out.push({
+    symbol,
+    mint: pos.mintAddress,
+    reserve: pos.reserveAddress,
+    amount: toNumber(tokenAmount),
+    valueUsd: toNumber(pos.marketValueRefreshed),
+    apyPercent: Number.isFinite(apy) ? apy * 100 : 0,
+    ...staleness,
+  });
+}
+```
+
+- [ ] **Step 5: Run type-check + full test suite**
+
+```bash
+pnpm exec tsc -b && pnpm test:run
+```
+
+Expected: zero TypeScript errors (interface extensions match call-site spreads). **138/138 tests passing** — no test changes, but full compile + run must succeed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tools/kamino.ts
+git commit -m "$(cat <<'EOF'
+feat(kamino): surface priceStale on yield + portfolio rows
+
+Extends YieldOpportunity and PortfolioPosition interfaces with
+priceStale: boolean and slotsSinceRefresh: number. findYield spreads
+computeStaleness into each row; mapPositions does the same with a
+ternary fallback for the existing reserve-undefined edge case
+(obligations referencing deleted reserves).
+EOF
+)"
+```
+
+---
+
+## Task 3: Update LLM system prompt
+
+**Files:**
+- Modify: `server/prompt.ts` (one rule expanded)
+
+- [ ] **Step 1: Update the "Numbers from tools" rule**
+
+In `server/prompt.ts`, find the existing line:
+
+```
+- Numbers from tools are live mainnet values. Quote them verbatim.
+```
+
+Replace it with:
+
+```
+- Numbers from tools are live mainnet values. Quote them verbatim.
+- If a yield or portfolio row has `priceStale: true`, prepend ⚠️ to that row in markdown tables and add a one-sentence footer like "Note: rows marked ⚠️ have oracle data > 60s old; numbers may lag the current market." Still quote the numbers — do NOT refuse the request.
+```
+
+The exact insertion is one new line immediately after the existing one. Both lines start with `- ` and continue the bulleted-rules style of the surrounding prompt.
+
+- [ ] **Step 2: Run type-check + full test suite**
+
+```bash
+pnpm exec tsc -b && pnpm test:run
+```
+
+Expected: zero TypeScript errors. **138/138 tests passing** — no test changes; the prompt is a string and not directly tested.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/prompt.ts
+git commit -m "$(cat <<'EOF'
+feat(prompt): flag stale oracle rows in markdown tables
+
+Adds one rule under the existing "Numbers from tools are live mainnet
+values" line. When findYield or getPortfolio returns a row with
+priceStale: true, the LLM prepends ⚠️ to that row and adds a single-
+sentence footer note. Numbers are still quoted — no refusal — to
+preserve the demo flow while surfacing the safety signal.
+EOF
+)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Final type-check + full suite + build**
+
+```bash
+pnpm exec tsc -b && pnpm test:run && pnpm build
+```
+
+Expected:
+- `pnpm exec tsc -b`: zero errors.
+- `pnpm test:run`: 138/138 across 16 files.
+- `pnpm build`: vite + tsc -b success; bundle size near current ~616 kB main.
+
+- [ ] **Push branch + open PR**
+
+```bash
+git push -u origin feat/d13-oracle-staleness-gate
+gh pr create --title "feat(chat): D-13 oracle-staleness gate on findYield/getPortfolio" --body "$(cat <<'EOF'
+## Summary
+
+Closes #7. Sprint 2.2 of Chunk 2 (per `docs/superpowers/specs/2026-04-26-qa-backlog-roadmap-design.md`).
+
+`reserve.getOracleMarketPrice()` returns the cached oracle price from the last `RefreshReserve`. If the underlying oracle has gone stale (Scope down, Pyth/Switchboard outage, no recent on-chain activity), users see numbers presented as live when they may be minutes old. This PR surfaces oracle freshness per row and instructs the LLM to flag stale rows with ⚠️ — while still quoting the numbers, to keep the demo flowing.
+
+## API ground truth (verified)
+
+The QA report flagged `reserve.getReserveOracleStatus()` as unverified. **Confirmed: that method does NOT exist** in `@kamino-finance/klend-sdk` 7.3. Verified ground truth via `node_modules/.../klend/types/LastUpdate.d.ts` and `dist/classes/reserve.d.ts`:
+
+- `reserve.state.lastUpdate.slot: BN` — last refresh slot (canonical signal we use)
+- `reserve.state.lastUpdate.stale: number` — transaction-level flag, NOT useful here
+- `reserve.state.lastUpdate.priceStatus: number` — undocumented enum, skipped
+
+We compute `slotsSinceRefresh = Number(currentSlot) - lastUpdate.slot.toNumber()` and gate on `> 150` slots (~60s @ 400ms/slot, matching Pyth/Switchboard convention).
+
+## Changes
+
+- `server/tools/kamino.ts`: new exported helper `computeStaleness(reserve, currentSlot)` returning `{ priceStale, slotsSinceRefresh }`. `YieldOpportunity` and `PortfolioPosition` extended with the two fields. `findYield` and `mapPositions` spread the helper output into their row pushes (with `mapPositions` ternary fallback for the existing reserve-undefined edge case).
+- `server/prompt.ts`: one rule added under "Numbers from tools are live mainnet values" instructing the LLM to prepend ⚠️ to stale rows in markdown tables + add a one-sentence footer. Still quotes numbers.
+- `server/tools/kamino.test.ts` (new file): 4 unit tests for `computeStaleness` covering fresh / stale / threshold-boundary / clock-skew-clamp paths. First test file for `kamino.ts` (the un-mocked surface per `CLAUDE.md`).
+
+## Spec + plan
+
+- Spec: `docs/superpowers/specs/2026-04-27-d13-oracle-staleness-design.md`
+- Plan: `docs/superpowers/plans/2026-04-27-d13-oracle-staleness-implementation.md`
+
+## Test plan
+
+- [x] `pnpm exec tsc -b` clean
+- [x] `pnpm test:run` — 138/138 passing across 16 files
+- [x] Per-task spec compliance review ✅ (Task 1, 2, 3)
+- [x] Per-task code quality review ✅ (Task 1, 2, 3)
+- [x] Final cluster review verdict
+- [ ] Manual smoke (post-merge prod): query "best USDC yield" — confirm rows include `priceStale: false` for active reserves; spot-check a low-traffic reserve to verify `priceStale: true` after sustained inactivity. Also verify the LLM renders ⚠️ + footer when stale data appears.
+EOF
+)"
+```
+
+- [ ] **Wait for CI + merge with `--merge` (keep branches)**
+
+```bash
+gh pr checks --watch
+gh pr merge --merge
+```
+
+- [ ] **Production smoke + close umbrella checkbox**
+
+After Vercel auto-deploys main:
+
+```bash
+# Quick health check
+curl -sS -X POST https://kami.rectorspace.com/api/rpc \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' -D - | head -5
+
+# Manual smoke in real browser, watch for priceStale field in tool output
+gh issue list --label qa-2026-04-26 --state open --limit 30  # expect 23 open (was 24)
+gh issue view 3   # ensure #7 ticked in umbrella
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- ✅ Problem framing → reflected in PR body + Task 1 commit message.
+- ✅ API ground truth verification → spec section preserved + Task 1 commit message references it.
+- ✅ Architecture diagram → reflected in code changes across Tasks 1, 2, 3.
+- ✅ `computeStaleness` helper + constant → Task 1 Step 3.
+- ✅ `YieldOpportunity` extension → Task 2 Step 1.
+- ✅ `PortfolioPosition` extension → Task 2 Step 2.
+- ✅ `findYield` call site spread → Task 2 Step 3.
+- ✅ `mapPositions` call site spread (with reserve-undefined guard) → Task 2 Step 4.
+- ✅ LLM prompt update → Task 3 Step 1.
+- ✅ 4 unit tests → Task 1 Step 1.
+- ✅ Coverage delta 134 → 138 → confirmed in Task 1 Step 5 + final verification.
+- ✅ Acceptance criteria checklist → Final verification + PR test plan.
+- ✅ `simulateHealth` left unchanged per scope → not modified in any task.
+
+**Placeholder scan:** No TBD/TODO/"add appropriate handling"/"similar to Task N". All steps have actual code.
+
+**Type consistency:** `computeStaleness(reserve: KaminoReserve, currentSlot: bigint): { priceStale: boolean; slotsSinceRefresh: number }` declared in Task 1 Step 3, called in Task 2 Step 3 + Step 4 with the same shape. `STALENESS_THRESHOLD_SLOTS = 150` declared in Task 1, used in `> 150` test boundary in Task 1 Step 1 (Test 3) and reflected in Task 1 Step 3 implementation. `priceStale: boolean` and `slotsSinceRefresh: number` field names consistent across interfaces (Task 2 Step 1, 2) and the helper return shape (Task 1 Step 3).

--- a/docs/superpowers/specs/2026-04-27-d13-oracle-staleness-design.md
+++ b/docs/superpowers/specs/2026-04-27-d13-oracle-staleness-design.md
@@ -1,0 +1,288 @@
+# D-13 — Oracle-staleness gate on findYield / getPortfolio
+
+**Date:** 2026-04-27
+**Issue:** [#7 — Oracle-staleness gate on findYield/getPortfolio output](https://github.com/RECTOR-LABS/kami/issues/7)
+**Priority:** P0 (`qa-2026-04-26`)
+**Sprint:** 2.2 (Chunk 2 — Test/Abort/Safety Extensions, Option C ordering: D-12 → **D-13** → D-11)
+**Estimate:** 2-4h
+**Branch:** `feat/d13-oracle-staleness-gate`
+
+---
+
+## Problem
+
+`reserve.getOracleMarketPrice()` returns the cached oracle price from the last `RefreshReserve` call. If the underlying oracle has gone stale (Scope down, Pyth/Switchboard validator outage, simply no recent on-chain activity for that reserve), the user sees yield/portfolio numbers presented as live mainnet values when they may be minutes or hours old. The current LLM system prompt (`server/prompt.ts:13`) instructs: *"Numbers from tools are live mainnet values. Quote them verbatim."*
+
+For the Eitherway-Kamino bounty judging, this is a reputation/trust risk. Judges will probe what happens when oracle data is stale — and getting "live" numbers that aren't actually live is a poor signal for a DeFi co-pilot.
+
+## Scope
+
+**In scope** (per brainstorm: `(a) 150 slots + (b-rich) + (c-warn)`):
+
+- Add a pure helper `computeStaleness(reserve, currentSlot)` in `server/tools/kamino.ts` that returns `{ priceStale: boolean; slotsSinceRefresh: number }` based on a 150-slot threshold (~60s @ 400ms/slot).
+- Surface both fields per row in `findYield` (extends `YieldOpportunity`) and `mapPositions` (extends `PortfolioPosition`).
+- Update LLM system prompt to instruct: when `priceStale: true`, prepend `⚠️` to the table row and add a one-sentence footer note. Quote numbers verbatim — do NOT refuse.
+- Add 4 unit tests in a new `server/tools/kamino.test.ts` covering the helper's threshold logic, boundary, stale path, and clock-skew clamp.
+
+**Out of scope** (explicitly deferred):
+
+- Apply staleness check to `simulateHealth` — depends on config (LTV thresholds), not market-stale oracle prices.
+- UI badges for stale rows — markdown emoji is sufficient for D-13; future UI sprint.
+- `priceStatus` enum interpretation — klend-sdk doesn't export enum values; slot-age is the canonical fallback.
+- Per-reserve or env-configurable threshold — global constant for hackathon scope.
+- Integration tests for `findYield` / `mapPositions` with stale reserves — those handlers are mainnet-validated per existing convention; unit-testing the pure helper is sufficient.
+
+## Verified API ground truth
+
+The handoff flagged `reserve.getReserveOracleStatus()` as unverified. **Confirmed: that method does NOT exist.** Verified via `node_modules/@kamino-finance/klend-sdk/dist/`:
+
+| Field | Type | What it means |
+|---|---|---|
+| `reserve.state.lastUpdate.slot` | `BN` | Last slot when reserve was refreshed (`.toNumber()` to convert) |
+| `reserve.state.lastUpdate.stale` | `number` (0/1) | **Transaction-level** flag — set when state-changing ix touches reserve, cleared on refresh. Always 0 outside a transaction. **NOT useful for our case.** |
+| `reserve.state.lastUpdate.priceStatus` | `number` | Enum status of prices used in last update. Values not exported in TypeScript. **Skip.** |
+
+**Canonical computable signal:**
+```ts
+const slotsSinceRefresh = Number(currentSlot) - reserve.state.lastUpdate.slot.toNumber();
+const priceStale = slotsSinceRefresh > 150;
+```
+
+**Threshold rationale (150 slots ≈ 60s):** aligns with Solana DeFi convention. Pyth's `STALE_PRICE_AGE_SECONDS` defaults to 60s; Switchboard recommends 30-60s. 60 slots is too aggressive (false-positives on idle off-peak reserves); 300 slots only catches catastrophic outages.
+
+## Architecture
+
+```
+findYield (kamino.ts:246)     mapPositions (kamino.ts:99)        computeStaleness (new helper)
+─────────────────────         ─────────────────────────         ─────────────────────────────
+per reserve in market         per position in obligation        input: KaminoReserve, bigint
+  → computeStaleness          → computeStaleness                output: { priceStale, slotsSinceRefresh }
+  → spread into row             → spread into row               logic: Number(currentSlot) -
+                                                                          reserve.state.lastUpdate.slot.toNumber()
+                                                                        priceStale = slotsSince > 150
+                                                                        slotsSinceRefresh clamped to ≥ 0
+
+server/prompt.ts updated rule
+─────────────────────────────
+"If priceStale: true, prepend ⚠️ to row + footer note. Still quote numbers."
+```
+
+### Key design decisions
+
+1. **One helper, exported for tests.** Matches `toNumber`, `computeUtilizationPercent`, `computeHealthFactor` precedent in the same file.
+2. **Threshold = `STALENESS_THRESHOLD_SLOTS = 150`** as a top-level constant. Tunable via single edit; no env override (YAGNI for hackathon).
+3. **Negative `slotsSinceRefresh` clamped to 0** — handles RPC clock skew where reserve refresh slot is ahead of `currentSlot` we just fetched.
+4. **`priceStale` boolean is what the LLM gates on; `slotsSinceRefresh` is for transparency** (ops debugging, future UI badges, optional LLM-quoted freshness).
+5. **No `simulateHealth` changes.** Out of scope — depends on config (LTV thresholds), not market-stale oracle prices.
+
+## Code changes
+
+### `server/tools/kamino.ts` — 4 surgical changes
+
+**Change 1: add constant + helper (around line 79, near other helpers):**
+
+```ts
+const STALENESS_THRESHOLD_SLOTS = 150;  // ~60s @ ~400ms/slot — Solana DeFi convention (Pyth, Switchboard)
+
+export function computeStaleness(
+  reserve: KaminoReserve,
+  currentSlot: bigint,
+): { priceStale: boolean; slotsSinceRefresh: number } {
+  const lastSlot = reserve.state.lastUpdate.slot.toNumber();
+  const slotsSinceRefresh = Math.max(0, Number(currentSlot) - lastSlot);
+  return {
+    priceStale: slotsSinceRefresh > STALENESS_THRESHOLD_SLOTS,
+    slotsSinceRefresh,
+  };
+}
+```
+
+**Change 2: extend `YieldOpportunity` (line 201-211):**
+
+```ts
+export interface YieldOpportunity {
+  symbol: string;
+  mint: string;
+  reserve: string;
+  side: 'supply' | 'borrow';
+  apyPercent: number;
+  ltvRatio: number;
+  liquidationLtv: number;
+  utilizationPercent: number;
+  marketPriceUsd: number;
+  priceStale: boolean;          // NEW
+  slotsSinceRefresh: number;    // NEW
+}
+```
+
+**Change 3: extend `PortfolioPosition` (line 38-45):**
+
+```ts
+export interface PortfolioPosition {
+  symbol: string;
+  mint: string;
+  reserve: string;
+  amount: number;
+  valueUsd: number;
+  apyPercent: number;
+  priceStale: boolean;          // NEW
+  slotsSinceRefresh: number;    // NEW
+}
+```
+
+**Change 4: spread staleness into both call sites:**
+
+```ts
+// findYield (line 246-256)
+opportunities.push({
+  symbol,
+  mint: reserve.stats.mintAddress,
+  reserve: reserve.address,
+  side,
+  apyPercent: apy * 100,
+  ltvRatio: reserve.stats.loanToValue,
+  liquidationLtv: reserve.stats.liquidationThreshold,
+  utilizationPercent: computeUtilizationPercent(reserve),
+  marketPriceUsd: toNumber(reserve.getOracleMarketPrice()),
+  ...computeStaleness(reserve, currentSlot),
+});
+
+// mapPositions (line 99-106)
+const staleness = reserve
+  ? computeStaleness(reserve, currentSlot)
+  : { priceStale: false, slotsSinceRefresh: 0 };
+out.push({
+  symbol,
+  mint: pos.mintAddress,
+  reserve: pos.reserveAddress,
+  amount: toNumber(tokenAmount),
+  valueUsd: toNumber(pos.marketValueRefreshed),
+  apyPercent: Number.isFinite(apy) ? apy * 100 : 0,
+  ...staleness,
+});
+```
+
+### `server/prompt.ts` — one rule expanded
+
+Replace the existing line 13:
+```
+- Numbers from tools are live mainnet values. Quote them verbatim.
+```
+
+With:
+```
+- Numbers from tools are live mainnet values. Quote them verbatim.
+- If a yield or portfolio row has `priceStale: true`, prepend ⚠️ to that row in markdown tables and add a one-sentence footer like "Note: rows marked ⚠️ have oracle data > 60s old; numbers may lag the current market." Still quote the numbers — do NOT refuse the request.
+```
+
+## Testing
+
+### `server/tools/kamino.test.ts` — new file, 4 unit tests
+
+```ts
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import BN from 'bn.js';
+import { computeStaleness } from './kamino';
+import type { KaminoReserve } from '@kamino-finance/klend-sdk';
+
+const BASELINE_SLOT = 1000n;
+
+function reserveAt(slot: number): KaminoReserve {
+  return {
+    state: { lastUpdate: { slot: new BN(slot) } },
+  } as unknown as KaminoReserve;
+}
+
+describe('computeStaleness', () => {
+  it('returns priceStale=false for a fresh reserve (50 slots old)', () => {
+    const r = reserveAt(950);
+    expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
+      priceStale: false,
+      slotsSinceRefresh: 50,
+    });
+  });
+
+  it('returns priceStale=true for a stale reserve (200 slots old)', () => {
+    const r = reserveAt(800);
+    expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
+      priceStale: true,
+      slotsSinceRefresh: 200,
+    });
+  });
+
+  it('returns priceStale=false at the exact threshold (150 slots old) — uses > not >=', () => {
+    const r = reserveAt(850);
+    expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
+      priceStale: false,
+      slotsSinceRefresh: 150,
+    });
+  });
+
+  it('clamps negative slot diffs to 0 (RPC clock skew defense)', () => {
+    const r = reserveAt(1010);
+    expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
+      priceStale: false,
+      slotsSinceRefresh: 0,
+    });
+  });
+});
+```
+
+### Why no integration test for `findYield` / `mapPositions`
+
+Those handlers are mainnet-validated per CLAUDE.md (kamino.ts is the un-mocked surface). Mock-driven integration would require fake `KaminoMarket.load()` + fake reserves — low ROI. The new fields appear in tool output via type system at compile time. Manual smoke (post-merge) verifies in production.
+
+### Coverage delta
+
+| Suite | Before | After |
+|---|---|---|
+| Total tests | 134 | **138** |
+| Test files | 15 | **16** |
+| `server/tools/kamino.test.ts` tests | 0 | 4 |
+
+## Edge cases
+
+| Edge case | Handling |
+|---|---|
+| `BN.toNumber()` overflow | Solana slot counts (~290M as of 2026) are far below 2^53. Safe for centuries. |
+| Negative `slotsSinceRefresh` from RPC clock skew | Clamped to 0 via `Math.max(0, ...)`. Test 4 enforces. |
+| Reserve with no `state.lastUpdate` | Anchor schema makes `lastUpdate` non-optional. TypeScript catches mismatches at compile time. |
+| `currentSlot` = bigint vs number | `Number(currentSlot)` conversion is safe for slot range. |
+| `reserve` undefined in `mapPositions` | Existing handler already guards `KaminoReserve | undefined`. Ternary fallback `{ priceStale: false, slotsSinceRefresh: 0 }` for the missing-reserve case. |
+| LLM doesn't always render ⚠️ | Best-effort prompt compliance; the boolean is in the data and visible to judges/devs. Acceptable trade-off — non-deterministic LLM output is a known property. |
+| `react-markdown` rendering ⚠️ in tables | Renders correctly as inline emoji; no special handler needed. |
+| Test stub `as unknown as KaminoReserve` | Stub bypasses full type check at construction. The helper itself is type-checked against the real `KaminoReserve` import — any klend-sdk shape change breaks compilation of the helper, not the stub. |
+
+## Non-goals — explicitly deferred
+
+| Item | Where it goes |
+|---|---|
+| Apply staleness to `simulateHealth` | Future iteration if real demand emerges. simulateHealth is a "hypothetical" computation; LTV thresholds it depends on are config, not market-stale. |
+| UI badges for stale rows | Future UI sprint can add tooltip / colored badge. Markdown ⚠️ is sufficient for D-13. |
+| `priceStatus` enum interpretation | klend-sdk doesn't export enum values. Slot-age is the canonical fallback. |
+| Per-reserve / env-configurable threshold | Global `STALENESS_THRESHOLD_SLOTS = 150` for hackathon scope. |
+| Integration tests for `findYield` / `mapPositions` | Validated via mainnet per existing project convention. |
+
+## Acceptance criteria
+
+- [ ] `pnpm exec tsc -b` clean.
+- [ ] `pnpm test:run` — 138/138 passing across 16 files.
+- [ ] All 4 `computeStaleness` unit tests pass.
+- [ ] `findYield` tool output includes `priceStale` and `slotsSinceRefresh` per row.
+- [ ] `getPortfolio` tool output includes `priceStale` and `slotsSinceRefresh` per `deposits[]` and `borrows[]` row.
+- [ ] LLM system prompt updated with the new staleness rule.
+- [ ] Manual smoke (post-merge prod): query `findYield` for "best USDC yield" — confirm rows include `priceStale: false` for active reserves; spot-check that a low-traffic reserve (if any) returns `priceStale: true` after a few minutes of inactivity.
+- [ ] Issue #7 closed by the merge commit (via `Closes #7` in PR body).
+
+## Risks
+
+- **Threshold mis-tuned for production:** 150 slots may be too aggressive or too lenient depending on real reserve refresh patterns. Mitigation: it's a one-line edit; can tune post-deploy based on observed false-positive / false-negative rates from Vercel logs and judge feedback.
+- **LLM compliance is non-deterministic:** the LLM may occasionally fail to render `⚠️` or omit the footer. Mitigation: the boolean is in the data; judges inspecting tool output will see the gate is real.
+- **`reserve.state` shape change in future klend-sdk version:** breaking change would surface as TypeScript error in the helper at compile time. Mitigation: pin guard CI workflow already locks klend-sdk to current major. Manual upgrade required for breaking-change adoption.
+
+## Acceptance — done when
+
+> "Would this survive a security audit?" Yes — read-only computation, no new attack surface.
+> "Would I deploy this to mainnet tonight?" Yes — pure helper with unit tests; LLM prompt change is reversible by editing one string.
+> "Will the next developer understand why I made these choices?" The constant + threshold + helper signature are self-documenting; this spec records the API verification trail (`getReserveOracleStatus` does not exist; we use slot-age) for future archaeologists.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/bn.js": "^5.2.0",
     "@types/node": "^25.6.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/bn.js':
+        specifier: ^5.2.0
+        version: 5.2.0
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -1473,6 +1476,9 @@ packages:
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/bn.js@5.2.0':
+    resolution: {integrity: sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -5817,6 +5823,10 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@types/bn.js@5.2.0':
+    dependencies:
+      '@types/node': 25.6.0
 
   '@types/chai@5.2.3':
     dependencies:

--- a/server/prompt.ts
+++ b/server/prompt.ts
@@ -11,6 +11,7 @@ Rules:
 - Use markdown formatting for readability (headings, lists, bold, links).
 - Never invent token mints, pool addresses, or APYs — if a tool returns no data, say so.
 - Numbers from tools are live mainnet values. Quote them verbatim.
+- If a yield or portfolio row has \`priceStale: true\`, prepend ⚠️ to that row in markdown tables and add a one-sentence footer like "Note: rows marked ⚠️ have oracle data > 60s old; numbers may lag the current market." Still quote the numbers — do NOT refuse the request.
 - Never produce raw transaction JSON blocks by hand — always call a build* tool. The frontend renders its own Sign & Send card from the tool result.
 - When a build* tool returns an error mentioning "insufficient SOL" or "rent", explain it as one-time account-rent needed by Kamino for this market. About ~0.022 SOL of that funds the obligation account itself and is permanently locked per (user, market) pair, because klend does not expose a close_obligation instruction; the remainder (cToken ATA rent + tx fee) is consumed as a network fee or recoverable when the ATAs are closed. Do not promise full refundability. Quote the shortfall amount verbatim and ask the user to top up before retrying. Do NOT re-call the build* tool in the same turn.
 

--- a/server/prompt.ts
+++ b/server/prompt.ts
@@ -11,7 +11,7 @@ Rules:
 - Use markdown formatting for readability (headings, lists, bold, links).
 - Never invent token mints, pool addresses, or APYs — if a tool returns no data, say so.
 - Numbers from tools are live mainnet values. Quote them verbatim.
-- If a yield or portfolio row has \`priceStale: true\`, prepend ⚠️ to that row in markdown tables and add a one-sentence footer like "Note: rows marked ⚠️ have oracle data > 60s old; numbers may lag the current market." Still quote the numbers — do NOT refuse the request.
+- If a yield or portfolio row has \`priceStale: true\`, prepend ⚠️ to that row in markdown tables and add a short note below the table: "Note: rows marked ⚠️ have oracle data > 60s old; numbers may lag the current market." Still quote the numbers — do NOT refuse the request.
 - Never produce raw transaction JSON blocks by hand — always call a build* tool. The frontend renders its own Sign & Send card from the tool result.
 - When a build* tool returns an error mentioning "insufficient SOL" or "rent", explain it as one-time account-rent needed by Kamino for this market. About ~0.022 SOL of that funds the obligation account itself and is permanently locked per (user, market) pair, because klend does not expose a close_obligation instruction; the remainder (cToken ATA rent + tx fee) is consumed as a network fee or recoverable when the ATAs are closed. Do not promise full refundability. Quote the shortfall amount verbatim and ask the user to top up before retrying. Do NOT re-call the build* tool in the same turn.
 

--- a/server/tools/kamino.test.ts
+++ b/server/tools/kamino.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import BN from 'bn.js';
+import { computeStaleness } from './kamino';
+import type { KaminoReserve } from '@kamino-finance/klend-sdk';
+
+const BASELINE_SLOT = 1000n;
+
+function reserveAt(slot: number): KaminoReserve {
+  return {
+    state: { lastUpdate: { slot: new BN(slot) } },
+  } as unknown as KaminoReserve;
+}
+
+describe('computeStaleness', () => {
+  it('returns priceStale=false for a fresh reserve (50 slots old)', () => {
+    const r = reserveAt(950);
+    expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
+      priceStale: false,
+      slotsSinceRefresh: 50,
+    });
+  });
+
+  it('returns priceStale=true for a stale reserve (200 slots old)', () => {
+    const r = reserveAt(800);
+    expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
+      priceStale: true,
+      slotsSinceRefresh: 200,
+    });
+  });
+
+  it('returns priceStale=false at the exact threshold (150 slots old) — uses > not >=', () => {
+    const r = reserveAt(850);
+    expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
+      priceStale: false,
+      slotsSinceRefresh: 150,
+    });
+  });
+
+  it('clamps negative slot diffs to 0 (RPC clock skew defense)', () => {
+    const r = reserveAt(1010);
+    expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
+      priceStale: false,
+      slotsSinceRefresh: 0,
+    });
+  });
+});

--- a/server/tools/kamino.ts
+++ b/server/tools/kamino.ts
@@ -42,6 +42,8 @@ export interface PortfolioPosition {
   amount: number;
   valueUsd: number;
   apyPercent: number;
+  priceStale: boolean;
+  slotsSinceRefresh: number;
 }
 
 export interface PortfolioSnapshot {
@@ -110,6 +112,9 @@ function mapPositions(
         ? reserve.totalSupplyAPY(currentSlot)
         : reserve.totalBorrowAPY(currentSlot)
       : 0;
+    const staleness = reserve
+      ? computeStaleness(reserve, currentSlot)
+      : { priceStale: false, slotsSinceRefresh: 0 };
     out.push({
       symbol,
       mint: pos.mintAddress,
@@ -117,6 +122,7 @@ function mapPositions(
       amount: toNumber(tokenAmount),
       valueUsd: toNumber(pos.marketValueRefreshed),
       apyPercent: Number.isFinite(apy) ? apy * 100 : 0,
+      ...staleness,
     });
   }
   return out;
@@ -222,6 +228,8 @@ export interface YieldOpportunity {
   liquidationLtv: number;
   utilizationPercent: number;
   marketPriceUsd: number;
+  priceStale: boolean;
+  slotsSinceRefresh: number;
 }
 
 function computeUtilizationPercent(reserve: KaminoReserve): number {
@@ -267,6 +275,7 @@ export const findYield: ToolDefinition<
         liquidationLtv: reserve.stats.liquidationThreshold,
         utilizationPercent: computeUtilizationPercent(reserve),
         marketPriceUsd: toNumber(reserve.getOracleMarketPrice()),
+        ...computeStaleness(reserve, currentSlot),
       });
     }
 

--- a/server/tools/kamino.ts
+++ b/server/tools/kamino.ts
@@ -80,6 +80,20 @@ export function toNumber(d: Decimal): number {
   return Number.isFinite(d.toNumber()) ? d.toNumber() : 0;
 }
 
+const STALENESS_THRESHOLD_SLOTS = 150;  // ~60s @ ~400ms/slot — Solana DeFi convention (Pyth, Switchboard)
+
+export function computeStaleness(
+  reserve: KaminoReserve,
+  currentSlot: bigint,
+): { priceStale: boolean; slotsSinceRefresh: number } {
+  const lastSlot = reserve.state.lastUpdate.slot.toNumber();
+  const slotsSinceRefresh = Math.max(0, Number(currentSlot) - lastSlot);
+  return {
+    priceStale: slotsSinceRefresh > STALENESS_THRESHOLD_SLOTS,
+    slotsSinceRefresh,
+  };
+}
+
 function mapPositions(
   positions: IterableIterator<[Address, { reserveAddress: Address; mintAddress: Address; mintFactor: Decimal; amount: Decimal; marketValueRefreshed: Decimal }]>,
   market: KaminoMarket,


### PR DESCRIPTION
## Summary

Closes #7. Sprint 2.2 of Chunk 2 (per `docs/superpowers/specs/2026-04-26-qa-backlog-roadmap-design.md`).

`reserve.getOracleMarketPrice()` returns the cached oracle price from the last `RefreshReserve`. If the underlying oracle has gone stale (Scope down, Pyth/Switchboard outage, no recent on-chain activity), users see numbers presented as live when they may be minutes old. This PR surfaces oracle freshness per row and instructs the LLM to flag stale rows with ⚠️ — while still quoting the numbers, to keep the demo flowing.

## API ground truth (verified)

The QA report flagged `reserve.getReserveOracleStatus()` as unverified. **Confirmed: that method does NOT exist** in `@kamino-finance/klend-sdk` 7.3. Verified ground truth via `node_modules/.../klend/types/LastUpdate.d.ts` and `dist/classes/reserve.d.ts`:

- `reserve.state.lastUpdate.slot: BN` — last refresh slot (canonical signal we use)
- `reserve.state.lastUpdate.stale: number` — transaction-level flag, NOT useful here
- `reserve.state.lastUpdate.priceStatus: number` — undocumented enum, skipped

We compute `slotsSinceRefresh = Number(currentSlot) - lastUpdate.slot.toNumber()` and gate on `> 150` slots (~60s @ 400ms/slot, matching Pyth/Switchboard convention). Negative slot diffs are clamped to 0 (RPC clock-skew defense).

## Changes

- `server/tools/kamino.ts`: new exported helper `computeStaleness(reserve, currentSlot)` returning `{ priceStale, slotsSinceRefresh }`. `YieldOpportunity` and `PortfolioPosition` extended with the two fields. `findYield` and `mapPositions` spread the helper output into their row pushes (with `mapPositions` ternary fallback `{ priceStale: false, slotsSinceRefresh: 0 }` for the existing reserve-undefined edge case).
- `server/prompt.ts`: one rule added under "Numbers from tools are live mainnet values" instructing the LLM to prepend ⚠️ to stale rows in markdown tables + add a short note below the table. Still quotes numbers — does NOT refuse.
- `server/tools/kamino.test.ts` (new file): 4 unit tests for `computeStaleness` covering fresh / stale / threshold-boundary / clock-skew-clamp paths. First test file for `kamino.ts` (the un-mocked surface per `CLAUDE.md`).

Total: 4 implementation commits (helper, wiring, prompt, prompt-clarity refinement) on top of 2 docs commits (spec + plan).

## Spec + plan

- Spec: `docs/superpowers/specs/2026-04-27-d13-oracle-staleness-design.md`
- Plan: `docs/superpowers/plans/2026-04-27-d13-oracle-staleness-implementation.md`

## Reviews completed

- Per-task spec compliance review ✅ (Task 1, 2, 3)
- Per-task code quality review ✅ (Task 1: 0/0/3 minor; Task 2: 0/0/2 minor; Task 3 round-1 surfaced 1 Important — "footer" was ambiguous to LLM, fixed in commit `4438251`; round-2 ✅)
- Final cluster review (base `87577ec` → head `4438251`): **SHIP IT**. 0 Critical, 0 Important, 4 Minor (all observation-only deferrals).

## Test plan

- [x] `pnpm exec tsc -b` clean
- [x] `pnpm test:run` — 138/138 passing across 16 files
- [x] `pnpm build` clean (vite + tsc -b; bundle envelope unchanged at ~616 kB)
- [x] Per-task and final cluster reviews complete
- [x] Manual smoke (post-merge prod) — verified 2026-04-27 17:40 local (data path: tool emits priceStale + slotsSinceRefresh per row; USDC 140 slots → false → no ⚠️ rendered as expected; SOL/tBTC/FDUSD over threshold but did not surface in this query). Threshold-tuning observation: 3/5 reserves crossed 150-slot threshold simultaneously; spec-flagged risk confirmed empirically — consider follow-up tuning to ~300-600 slots to reduce false-positives.