### PR TITLE
chore(kamino): tune oracle-staleness threshold 150 → 600 slots

### DIFF
--- a/server/prompt.ts
+++ b/server/prompt.ts
@@ -11,7 +11,7 @@ Rules:
 - Use markdown formatting for readability (headings, lists, bold, links).
 - Never invent token mints, pool addresses, or APYs — if a tool returns no data, say so.
 - Numbers from tools are live mainnet values. Quote them verbatim.
-- If a yield or portfolio row has \`priceStale: true\`, prepend ⚠️ to that row in markdown tables and add a short note below the table: "Note: rows marked ⚠️ have oracle data > 60s old; numbers may lag the current market." Still quote the numbers — do NOT refuse the request.
+- If a yield or portfolio row has \`priceStale: true\`, prepend ⚠️ to that row in markdown tables and add a short note below the table: "Note: rows marked ⚠️ have oracle data > 4 minutes old; numbers may lag the current market." Still quote the numbers — do NOT refuse the request.
 - Never produce raw transaction JSON blocks by hand — always call a build* tool. The frontend renders its own Sign & Send card from the tool result.
 - When a build* tool returns an error mentioning "insufficient SOL" or "rent", explain it as one-time account-rent needed by Kamino for this market. About ~0.022 SOL of that funds the obligation account itself and is permanently locked per (user, market) pair, because klend does not expose a close_obligation instruction; the remainder (cToken ATA rent + tx fee) is consumed as a network fee or recoverable when the ATAs are closed. Do not promise full refundability. Quote the shortfall amount verbatim and ask the user to top up before retrying. Do NOT re-call the build* tool in the same turn.
 

--- a/server/tools/kamino.test.ts
+++ b/server/tools/kamino.test.ts
@@ -21,19 +21,19 @@ describe('computeStaleness', () => {
     });
   });
 
-  it('returns priceStale=true for a stale reserve (200 slots old)', () => {
-    const r = reserveAt(800);
+  it('returns priceStale=true for a stale reserve (700 slots old)', () => {
+    const r = reserveAt(300);
     expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
       priceStale: true,
-      slotsSinceRefresh: 200,
+      slotsSinceRefresh: 700,
     });
   });
 
-  it('returns priceStale=false at the exact threshold (150 slots old) — uses > not >=', () => {
-    const r = reserveAt(850);
+  it('returns priceStale=false at the exact threshold (600 slots old) — uses > not >=', () => {
+    const r = reserveAt(400);
     expect(computeStaleness(r, BASELINE_SLOT)).toEqual({
       priceStale: false,
-      slotsSinceRefresh: 150,
+      slotsSinceRefresh: 600,
     });
   });
 

--- a/server/tools/kamino.ts
+++ b/server/tools/kamino.ts
@@ -82,7 +82,7 @@ export function toNumber(d: Decimal): number {
   return Number.isFinite(d.toNumber()) ? d.toNumber() : 0;
 }
 
-const STALENESS_THRESHOLD_SLOTS = 150;  // ~60s @ ~400ms/slot — Solana DeFi convention (Pyth, Switchboard)
+const STALENESS_THRESHOLD_SLOTS = 600;  // ~4 min @ ~400ms/slot — empirically tuned (post-D-13 smoke 2026-04-27); 150-slot baseline produced too many false-positives on idle reserves
 
 export function computeStaleness(
   reserve: KaminoReserve,


### PR DESCRIPTION
## Summary

Empirical post-deploy tuning of the D-13 oracle-staleness gate. The smoke run on 2026-04-27 (PR #33 follow-up) showed 3 of 5 reserves on USDC's market crossing the 150-slot threshold simultaneously on a typical mainnet snapshot — too noisy to be useful as a "warn the judge" signal during the demo.

## Empirical evidence (snapshot 2026-04-27 17:40 local)

| Reserve | slotsSinceRefresh | Old gate (150) | New gate (600) |
|---|---|---|---|
| USDC | 140 | false (just under) | false |
| USDG | 52 | false | false |
| SOL | 169 | **true** | false |
| tBTC | 326 | **true** | false |
| FDUSD | 6662 | true | true (genuinely stale ≈ 44 min) |

Under the new threshold, only the genuinely-stale reserve (FDUSD at 44 min idle) trips the gate. The signal-to-noise ratio is preserved without crying wolf on routine queries.

## Changes

- `server/tools/kamino.ts`: `STALENESS_THRESHOLD_SLOTS = 150` → `600` (~4 min @ 400ms/slot). Comment updated to record empirical rationale.
- `server/tools/kamino.test.ts`: 2 fixture updates — stale-reserve test now uses 700 slots, threshold-boundary test now uses 600 slots. Test naming preserved at the slot-count level so the `> not >=` invariant still reads correctly.
- `server/prompt.ts`: footer note "60s old" → "4 minutes old" to keep user-facing text consistent with the gate.

## Test plan

- [x] `pnpm exec tsc --noEmit` (client) clean
- [x] `pnpm exec tsc -p server/tsconfig.json --noEmit` (server) clean
- [x] `pnpm test:run` — 138/138 across 16 files
- [ ] Manual smoke (post-merge): re-query "best USDC yield" and confirm stale-reserve count drops to ~1 of 5 (only genuinely-idle reserves like FDUSD remain flagged).

## Spec alignment

The original spec at `docs/superpowers/specs/2026-04-27-d13-oracle-staleness-design.md` explicitly flagged this risk:

> "Threshold mis-tuned for production: 150 slots may be too aggressive or too lenient depending on real reserve refresh patterns. Mitigation: it's a one-line edit; can tune post-deploy based on observed false-positive / false-negative rates from Vercel logs and judge feedback."

This PR is exactly that one-line tune.