### PR TITLE
feat: P1 cluster — server hygiene + UI polish + useChat test expansion

### DIFF
--- a/api/rpc.test.ts
+++ b/api/rpc.test.ts
@@ -163,7 +163,7 @@ describe('api/rpc handler', () => {
     expect(JSON.parse(cap.getBody()).error).toBe('Invalid JSON body');
   });
 
-  it('returns 403 when a denied method is in a single call', async () => {
+  it('returns 403 when a disallowed method is in a single call', async () => {
     const req = makeReq({
       body: '{"jsonrpc":"2.0","id":1,"method":"getProgramAccounts"}',
     });
@@ -175,7 +175,7 @@ describe('api/rpc handler', () => {
     expect(body.hint).toContain('Helius');
   });
 
-  it('returns 403 when a denied method is in a batch', async () => {
+  it('returns 403 when a disallowed method is in a batch', async () => {
     const req = makeReq({
       body: JSON.stringify([
         { jsonrpc: '2.0', id: 1, method: 'getHealth' },
@@ -232,7 +232,7 @@ describe('api/rpc handler', () => {
         headers: { 'content-type': 'application/json' },
       });
     });
-    const payload = '{"jsonrpc":"2.0","id":1,"method":"getSlot"}';
+    const payload = '{"jsonrpc":"2.0","id":1,"method":"getBalance"}';
     const req = makeReq({ body: payload });
     const cap = makeRes();
     await handler(req, cap.res);

--- a/api/rpc.ts
+++ b/api/rpc.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { applyLimit, identify, type LimitResult } from '../server/ratelimit.js';
-import { deniedMethodIn, oversizedParamsIn } from '../server/rpc-guards.js';
+import { disallowedMethodIn, oversizedParamsIn } from '../server/rpc-guards.js';
 
 export const config = {
   maxDuration: 30,
@@ -82,13 +82,13 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
     return;
   }
 
-  const denied = deniedMethodIn(parsed);
-  if (denied) {
+  const disallowed = disallowedMethodIn(parsed);
+  if (disallowed) {
     res.statusCode = 403;
     res.setHeader('Content-Type', 'application/json');
     res.end(
       JSON.stringify({
-        error: `RPC method "${denied}" is not allowed through this proxy`,
+        error: `RPC method "${disallowed}" is not allowed through this proxy`,
         hint: 'Use a public RPC or your own Helius key for heavy historical queries.',
       }),
     );

--- a/docs/superpowers/plans/2026-04-28-p1-cluster.md
+++ b/docs/superpowers/plans/2026-04-28-p1-cluster.md
@@ -1,0 +1,1100 @@
+# Sprint 4.3 — P1 cluster Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the remaining 6 P1 items in the `qa-2026-04-26` backlog — three server-hygiene improvements (#9 D-5, #10 D-9, #11 D-10), two UI polish affordances (#14 U-5, #15 U-7), and useChat test expansion (#12 D-11). After this PR merges, the entire 2026-04-26 baseline-QA backlog is closed and umbrella issue #3 ticks all rows.
+
+**Architecture:** Six commits, one per logical change. No new abstractions, no new modules. Items 1-5 modify existing files only; item 6 adds one new test file (`src/components/EmptyState.test.tsx`). Item 4 (#12 D-11) targets the actual coverage gap — D-3 and D-4 regression cases already have tests; the gap is `sendMessage` streaming text-delta accumulation + tool-call sequencing + the in-input `stopStreaming` abort path.
+
+**Tech Stack:** TypeScript, React 18, Vite, Vitest 4.x with `@testing-library/react`, Tailwind. happy-dom test environment. `crypto.randomUUID()` (Node 24 / browser standard). No new dependencies.
+
+**Branch:** `feat/p1-cluster` (already created with the design spec at `7f864d5`).
+
+---
+
+## File Structure
+
+| File | Disposition | Tasks | Responsibility |
+|---|---|---|---|
+| `src/hooks/useChat.ts` | Modify | 1 | Single-character fix to fetch path |
+| `server/ratelimit.ts` | Modify | 2 | Add cached `DEV_TOKEN` + return it from `identify()` in non-prod |
+| `server/ratelimit.test.ts` | Modify (extend) | 2 | +1 test asserting dev-token shape |
+| `server/rpc-guards.ts` | Modify | 3 | `DENIED_METHODS` → `ALLOWED_METHODS`; rename function; flip return semantics |
+| `server/rpc-guards.test.ts` | Modify (rewrite tests) | 3 | Flip semantics on existing tests; add 1 allowlist-membership assertion |
+| `api/rpc.ts` | Modify | 3 | Update import + call site for renamed function |
+| `src/hooks/useChat.test.ts` | Modify (extend) | 4 | +4 tests: streaming text-delta, tool sequencing, tool error, stopStreaming abort |
+| `src/components/Sidebar.tsx` | Modify | 5 | Add `title={conv.title}` attribute to the static-title `<span>` |
+| `src/components/EmptyState.tsx` | Modify | 6 | Accept `onSend` prop; add `onClick` + `cursor-pointer` to each card |
+| `src/components/ChatPanel.tsx` | Modify | 6 | Pass `handleSend` as `onSend` to `<EmptyState>` |
+| `src/components/EmptyState.test.tsx` | Create | 6 | NEW; 5 tests (4 card-click + 1 smoke) |
+
+---
+
+## Task 1: #9 D-5 — Drop relative fetch path (no test, single-char fix)
+
+**Files:**
+- Modify: `src/hooks/useChat.ts:182`
+
+**Pattern:** Static path correction. No new tests — covered by every existing integration path that hits `/api/chat`.
+
+- [ ] **Step 1: Edit `src/hooks/useChat.ts:182`**
+
+Open the file. The current line at 182 reads:
+
+```typescript
+        const response = await fetch('api/chat', {
+```
+
+Change to:
+
+```typescript
+        const response = await fetch('/api/chat', {
+```
+
+That is the only change. The single character fix turns the relative URL into an absolute path.
+
+- [ ] **Step 2: Run the gate set**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm test:run
+```
+
+Expected: all silent. Test count: 175/175 across 20 files (unchanged).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useChat.ts
+git commit -m "$(cat <<'EOF'
+fix(chat): use absolute path for /api/chat fetch
+
+The relative form fetch('api/chat') resolves against the current document
+URL. If the SPA is ever served from a non-root sub-path or react-router
+pushes the URL into a sub-segment without a trailing slash, the request
+hits the wrong endpoint. Absolute path is the standard.
+
+Closes #9
+EOF
+)"
+```
+
+---
+
+## Task 2: #10 D-9 — Random per-process token in dev (TDD)
+
+**Files:**
+- Modify: `server/ratelimit.ts`
+- Modify: `server/ratelimit.test.ts`
+
+**Pattern:** TDD red → green. Add the test first, run to confirm fail, implement, run to pass.
+
+- [ ] **Step 1: Add the failing test to `server/ratelimit.test.ts`**
+
+Open `server/ratelimit.test.ts`. The existing `describe('identify', ...)` block contains 7 tests. Append a new test inside that block (just before its closing `});` at line 89):
+
+```typescript
+  it('returns a dev-prefixed UUID-shaped token outside production when no IP headers are present', () => {
+    const origEnv = process.env.NODE_ENV;
+    delete process.env.NODE_ENV;
+    try {
+      const id = identify(mockReq({}));
+      expect(id).toMatch(/^dev-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    } finally {
+      if (origEnv !== undefined) process.env.NODE_ENV = origEnv;
+    }
+  });
+```
+
+Note: the existing test "returns 'anonymous' when no IP headers are present outside production" at line 59-67 is now obsolete — the new behavior is a `dev-` UUID, not the literal `'anonymous'`. Delete that test entirely (lines 59-67 inclusive). The new test above replaces it.
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+pnpm test:run server/ratelimit.test.ts
+```
+
+Expected: the new test fails (current `identify()` returns `'anonymous'`, which doesn't match the regex). All other tests pass.
+
+- [ ] **Step 3: Implement the dev-token in `server/ratelimit.ts`**
+
+Open `server/ratelimit.ts`. After the existing imports + `Duration` type alias (lines 1-5) but before `export interface LimiterConfig` (line 7), add a module-level cached token:
+
+```typescript
+const DEV_TOKEN: string = `dev-${typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : 'fallback-' + Date.now().toString(36)}`;
+```
+
+Then update `identify()`. Current body at line 52-66:
+
+```typescript
+export function identify(req: IncomingMessage): string {
+  const xfwd = req.headers['x-forwarded-for'];
+  const xreal = req.headers['x-real-ip'];
+
+  const fwdStr = Array.isArray(xfwd) ? xfwd[0] : xfwd;
+  const fromFwd = typeof fwdStr === 'string' ? fwdStr.split(',')[0]?.trim() : '';
+  const fromReal = typeof xreal === 'string' ? xreal.trim() : '';
+  const ip = fromFwd || fromReal;
+
+  if (ip) return ip;
+  // Vercel always populates x-forwarded-for on incoming traffic. A missing IP
+  // in production is anomalous — refuse to bucket every such caller under a
+  // shared 'anonymous' key that a single actor could then exhaust and DoS.
+  return process.env.NODE_ENV === 'production' ? '' : 'anonymous';
+}
+```
+
+Replace the comment + return statement (the last line) with:
+
+```typescript
+  if (ip) return ip;
+  // Vercel always populates x-forwarded-for on incoming traffic. A missing IP
+  // in production is anomalous — refuse to bucket every such caller under a
+  // shared key that a single actor could then exhaust and DoS. Outside
+  // production, return a per-process random token so a dev build accidentally
+  // pointed at the real Upstash doesn't share the 'anonymous' bucket with
+  // every other dev caller.
+  return process.env.NODE_ENV === 'production' ? '' : DEV_TOKEN;
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+pnpm test:run server/ratelimit.test.ts
+```
+
+Expected: all tests pass (including the new `dev-prefixed UUID-shaped token` test).
+
+- [ ] **Step 5: Run the full gate set**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm test:run
+```
+
+Expected: all silent. Test count: 175 → 175 across 20 files (1 deleted + 1 added = 0 net change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/ratelimit.ts server/ratelimit.test.ts
+git commit -m "$(cat <<'EOF'
+fix(ratelimit): randomize dev identifier per process
+
+In non-production, identify() returned the literal 'anonymous' when no IP
+headers resolved. A dev build accidentally pointed at the real Upstash
+would share that bucket with every other anonymous caller — a single curl
+loop could exhaust the bucket for the entire local session.
+
+Cache 'dev-' + crypto.randomUUID() at module load and return it instead.
+Production behavior unchanged — a missing IP still fails closed with the
+empty-string identifier. Replace the obsolete 'anonymous' assertion in the
+existing identify-test with a regex matching the new dev-token shape.
+
+Closes #10
+EOF
+)"
+```
+
+---
+
+## Task 3: #11 D-10 — Switch RPC guard from denylist to allowlist
+
+**Files:**
+- Modify: `server/rpc-guards.ts`
+- Modify: `server/rpc-guards.test.ts`
+- Modify: `api/rpc.ts`
+
+**Pattern:** Code-first then update tests. The semantics flip is structural; the tests get rewritten in lockstep.
+
+- [ ] **Step 1: Replace `DENIED_METHODS` with `ALLOWED_METHODS` in `server/rpc-guards.ts`**
+
+Open `server/rpc-guards.ts`. Replace the entire file content with:
+
+```typescript
+export const MAX_BATCH_SIZE = 20;
+export const MAX_PARAMS_ARRAY_LENGTH = 100;
+
+export const ALLOWED_METHODS = new Set([
+  // Connectivity / health
+  'getHealth',
+  // Transaction lifecycle
+  'getLatestBlockhash',
+  'simulateTransaction',
+  'sendTransaction',
+  'getSignatureStatuses',
+  'getBlockHeight',
+  'getMinimumBalanceForRentExemption',
+  // Wallet / account reads
+  'getBalance',
+  'getAccountInfo',
+  'getMultipleAccounts',
+]);
+
+export function disallowedMethodIn(payload: unknown): string | null {
+  const calls = Array.isArray(payload) ? payload : [payload];
+  for (const c of calls) {
+    if (c && typeof c === 'object' && typeof (c as { method?: unknown }).method === 'string') {
+      const method = (c as { method: string }).method;
+      if (!ALLOWED_METHODS.has(method)) return method;
+    }
+  }
+  return null;
+}
+
+// NOTE: This guard inspects only DIRECT array children of `params`. RPC methods
+// that wrap long arrays inside config objects (e.g.,
+// `params: [{ accounts: [...100 items...] }]`) would slip through. The current
+// ALLOWED_METHODS set covers methods whose direct-params shape is well-known;
+// if an allowlist addition has nested array params, audit this function for
+// recursive descent before relying on it.
+export function oversizedParamsIn(payload: unknown): string | null {
+  if (Array.isArray(payload) && payload.length > MAX_BATCH_SIZE) {
+    return `batch of ${payload.length} calls exceeds limit of ${MAX_BATCH_SIZE}`;
+  }
+  const calls = Array.isArray(payload) ? payload : [payload];
+  for (const c of calls) {
+    if (!c || typeof c !== 'object') continue;
+    const params = (c as { params?: unknown }).params;
+    if (!Array.isArray(params)) continue;
+    for (const p of params) {
+      if (Array.isArray(p) && p.length > MAX_PARAMS_ARRAY_LENGTH) {
+        return `params array length ${p.length} exceeds limit of ${MAX_PARAMS_ARRAY_LENGTH}`;
+      }
+    }
+  }
+  return null;
+}
+```
+
+Key changes:
+- `DENIED_METHODS` → `ALLOWED_METHODS` (positive list)
+- `deniedMethodIn` → `disallowedMethodIn` (returns the method name when NOT in the allowlist)
+- `oversizedParamsIn` is unchanged (only the comment header text adjusts to refer to "ALLOWED_METHODS")
+
+- [ ] **Step 2: Update `api/rpc.ts` for the renamed function**
+
+Open `api/rpc.ts`. Two locations need updates.
+
+**Edit A:** Update the import at line 3:
+
+```typescript
+import { deniedMethodIn, oversizedParamsIn } from '../server/rpc-guards.js';
+```
+
+Change to:
+
+```typescript
+import { disallowedMethodIn, oversizedParamsIn } from '../server/rpc-guards.js';
+```
+
+**Edit B:** Update the call site at line 85-96. Current:
+
+```typescript
+  const denied = deniedMethodIn(parsed);
+  if (denied) {
+    res.statusCode = 403;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(
+      JSON.stringify({
+        error: `RPC method "${denied}" is not allowed through this proxy`,
+        hint: 'Use a public RPC or your own Helius key for heavy historical queries.',
+      }),
+    );
+    return;
+  }
+```
+
+Change to:
+
+```typescript
+  const disallowed = disallowedMethodIn(parsed);
+  if (disallowed) {
+    res.statusCode = 403;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(
+      JSON.stringify({
+        error: `RPC method "${disallowed}" is not allowed through this proxy`,
+        hint: 'Use a public RPC or your own Helius key for heavy historical queries.',
+      }),
+    );
+    return;
+  }
+```
+
+(The error message stays — same 403 response surface; only the local variable name changes.)
+
+- [ ] **Step 3: Rewrite the existing tests in `server/rpc-guards.test.ts`**
+
+Open `server/rpc-guards.test.ts`. Replace the entire `describe('deniedMethodIn', ...)` block (lines 9-42) with this rewritten version targeting `disallowedMethodIn`:
+
+```typescript
+describe('disallowedMethodIn', () => {
+  it('returns null for an allowlisted method', () => {
+    expect(disallowedMethodIn({ jsonrpc: '2.0', id: 1, method: 'getHealth' })).toBeNull();
+  });
+
+  it('returns the method name when an arbitrary (non-allowlisted) method is used', () => {
+    expect(disallowedMethodIn({ jsonrpc: '2.0', id: 1, method: 'getProgramAccounts' })).toBe(
+      'getProgramAccounts',
+    );
+  });
+
+  it('returns the method name for newly-shipped Solana RPC methods (drift safety)', () => {
+    // Hypothetical future method — the allowlist explicitly opts in, so an
+    // unknown method 403s by default rather than silently relaying.
+    expect(disallowedMethodIn({ jsonrpc: '2.0', id: 1, method: 'getFutureBlockchainSomething' })).toBe(
+      'getFutureBlockchainSomething',
+    );
+  });
+
+  it('scans batch arrays and flags the first disallowed method', () => {
+    const batch = [
+      { jsonrpc: '2.0', id: 1, method: 'getHealth' },
+      { jsonrpc: '2.0', id: 2, method: 'getProgramAccounts' },
+    ];
+    expect(disallowedMethodIn(batch)).toBe('getProgramAccounts');
+  });
+
+  it('returns null for batches of allowlisted methods', () => {
+    const batch = [
+      { jsonrpc: '2.0', id: 1, method: 'getHealth' },
+      { jsonrpc: '2.0', id: 2, method: 'getBalance' },
+    ];
+    expect(disallowedMethodIn(batch)).toBeNull();
+  });
+
+  it('tolerates malformed payloads', () => {
+    expect(disallowedMethodIn(null)).toBeNull();
+    expect(disallowedMethodIn(undefined)).toBeNull();
+    expect(disallowedMethodIn('not an object')).toBeNull();
+    expect(disallowedMethodIn({ method: 42 })).toBeNull();
+  });
+});
+
+describe('ALLOWED_METHODS membership', () => {
+  it('includes every method the app actually uses', () => {
+    // This list is the contract — if the app starts using a new RPC method,
+    // add it here AND to ALLOWED_METHODS in rpc-guards.ts.
+    const expected = [
+      'getHealth',
+      'getLatestBlockhash',
+      'simulateTransaction',
+      'sendTransaction',
+      'getSignatureStatuses',
+      'getBlockHeight',
+      'getMinimumBalanceForRentExemption',
+      'getBalance',
+      'getAccountInfo',
+      'getMultipleAccounts',
+    ];
+    for (const method of expected) {
+      expect(ALLOWED_METHODS.has(method)).toBe(true);
+    }
+  });
+});
+```
+
+Then update the import at line 2-7. Current:
+
+```typescript
+import {
+  deniedMethodIn,
+  oversizedParamsIn,
+  MAX_BATCH_SIZE,
+  MAX_PARAMS_ARRAY_LENGTH,
+} from './rpc-guards';
+```
+
+Change to:
+
+```typescript
+import {
+  disallowedMethodIn,
+  oversizedParamsIn,
+  ALLOWED_METHODS,
+  MAX_BATCH_SIZE,
+  MAX_PARAMS_ARRAY_LENGTH,
+} from './rpc-guards';
+```
+
+The existing `describe('oversizedParamsIn', ...)` block (lines 44-90) does NOT change — those tests are independent of the allowlist switch.
+
+- [ ] **Step 4: Run the test file to confirm pass**
+
+```bash
+pnpm test:run server/rpc-guards.test.ts
+```
+
+Expected: all tests pass. Specifically, the 5 rewritten `disallowedMethodIn` tests + the 1 new `ALLOWED_METHODS membership` test + the 7 existing `oversizedParamsIn` tests = 13 tests.
+
+- [ ] **Step 5: Run the full gate set**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm test:run
+```
+
+Expected: all silent. Test count: 175 → 176 across 20 files (rpc-guards.test.ts: 12 → 13, +1 net for the membership test).
+
+- [ ] **Step 6: Manual smoke (BEFORE commit) — verify no legitimate methods 403**
+
+Run `pnpm dev`, then in a browser:
+
+1. Open https://localhost:5173 (or whatever port appears).
+2. Connect Solflare wallet (devnet OK).
+3. Submit a chat query like "show me my Kamino portfolio" — exercises wallet validation + reads.
+4. If wallet has any Kamino position, also try "deposit 5 USDC" to exercise the build-tx + simulate path.
+5. Open Browser DevTools → Network → filter for `/api/rpc`. Confirm:
+   - Every `/api/rpc` request returns 200 (or a legitimate upstream-RPC error like 502, NEVER 403).
+   - If a 403 appears with `error: "RPC method \"<X>\" is not allowed through this proxy"`, copy that method name. Add it to `ALLOWED_METHODS` in `server/rpc-guards.ts`. Add it to the membership-test array in `server/rpc-guards.test.ts`. Re-run the test file. Re-run the smoke.
+
+The starting allowlist above covers the 10 known direct paths. If the smoke surfaces a method we missed, document it and add it. Common candidates that may need adding: `getSlot`, `getEpochInfo`, `getRecentBlockhash` (deprecated but some adapters fall back to it), `getFeeForMessage`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/rpc-guards.ts server/rpc-guards.test.ts api/rpc.ts
+git commit -m "$(cat <<'EOF'
+fix(rpc-guards): switch from denylist to allowlist
+
+Solana adds new RPC methods regularly. A denylist must be maintained
+forever — the moment an expensive new method ships, the proxy carries the
+cost until someone updates the list.
+
+Replace DENIED_METHODS with ALLOWED_METHODS containing the 10 methods Kami
+actually calls (getHealth, getLatestBlockhash, simulateTransaction,
+sendTransaction, getSignatureStatuses, getBlockHeight,
+getMinimumBalanceForRentExemption, getBalance, getAccountInfo,
+getMultipleAccounts). Rename deniedMethodIn → disallowedMethodIn — same
+contract (returns method name when caught) but inverted membership check.
+Existing tests rewritten with flipped semantics; add a membership-test
+codifying the contract.
+
+Manual smoke against pnpm dev confirmed all wallet-sign + portfolio paths
+return 200, not 403.
+
+Closes #11
+EOF
+)"
+```
+
+---
+
+## Task 4: #12 D-11 — Expand `useChat.test.ts` for streaming + tool sequencing + stopStreaming abort (TDD)
+
+**Files:**
+- Modify: `src/hooks/useChat.test.ts`
+
+**Pattern:** TDD red → green per test. Use `global.fetch = vi.fn(...)` to return a `Response` with a hand-built SSE-style body, mirroring the existing `useChat 4xx error rendering integration` test (lines 175-194 in current file).
+
+**Coverage gap analysis:** The existing test file already covers:
+- D-3 (4xx → formatted error message): `useChat 4xx error rendering integration` block (line 166)
+- D-4 abort on switchConversation (via newConversation): `useChat abort behavior` line 93
+- D-4 abort on deleteConversation of active: line 116
+- D-4 NO abort on deleteConversation of non-active: line 138
+- abort on clearAllConversations: `useChat clearAllConversations` line 228 (Sprint 4.2b)
+
+What is NOT covered (the actual D-11 gap):
+- `sendMessage` text-delta accumulation through SSE chunks
+- `sendMessage` tool-call/tool-result/tool-error chunk handling
+- `stopStreaming()` (the in-input stop button) abort path
+
+This task adds 4 tests covering exactly this gap, no duplication.
+
+- [ ] **Step 1: Add the 4 failing tests to `src/hooks/useChat.test.ts`**
+
+Open `src/hooks/useChat.test.ts`. Append a new describe block at the end of the file (after the `useChat renameConversation` block ending at line 293):
+
+```typescript
+describe('useChat sendMessage streaming', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function streamResponse(chunks: string[]): Response {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+  }
+
+  it('accumulates text-delta chunks into the assistant message content', async () => {
+    global.fetch = vi.fn(async () =>
+      streamResponse([
+        'data: {"text":"Hello"}\n',
+        'data: {"text":", "}\n',
+        'data: {"text":"world."}\n',
+        'data: [DONE]\n',
+      ])
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      await result.current.sendMessage('hi');
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    const assistantMsg = result.current.activeConversation.messages.find((m) => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.content).toBe('Hello, world.');
+  });
+
+  it('threads toolCall + toolResult chunks into messages[last].toolCalls', async () => {
+    global.fetch = vi.fn(async () =>
+      streamResponse([
+        'data: {"toolCall":{"id":"tc-1","name":"getPortfolio"}}\n',
+        'data: {"toolResult":{"id":"tc-1","name":"getPortfolio","output":{"ok":true,"data":{"positions":[]}}}}\n',
+        'data: {"text":"You have no positions."}\n',
+        'data: [DONE]\n',
+      ])
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      await result.current.sendMessage('show me my portfolio');
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    const assistantMsg = result.current.activeConversation.messages.find((m) => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.toolCalls).toHaveLength(1);
+    expect(assistantMsg!.toolCalls![0].id).toBe('tc-1');
+    expect(assistantMsg!.toolCalls![0].name).toBe('getPortfolio');
+    expect(assistantMsg!.toolCalls![0].status).toBe('done');
+    expect(assistantMsg!.content).toBe('You have no positions.');
+  });
+
+  it('marks toolCalls as error when a toolError chunk arrives', async () => {
+    global.fetch = vi.fn(async () =>
+      streamResponse([
+        'data: {"toolCall":{"id":"tc-1","name":"buildDeposit"}}\n',
+        'data: {"toolError":{"id":"tc-1","name":"buildDeposit","error":"insufficient balance"}}\n',
+        'data: [DONE]\n',
+      ])
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      await result.current.sendMessage('deposit 5 USDC');
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    const assistantMsg = result.current.activeConversation.messages.find((m) => m.role === 'assistant');
+    expect(assistantMsg!.toolCalls).toHaveLength(1);
+    expect(assistantMsg!.toolCalls![0].status).toBe('error');
+    expect(assistantMsg!.toolCalls![0].error).toBe('insufficient balance');
+  });
+
+  it('aborts the in-flight stream when stopStreaming is called', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    global.fetch = vi.fn((_url: unknown, init: unknown) => {
+      capturedSignal = (init as RequestInit | undefined)?.signal ?? undefined;
+      return new Promise(() => {});
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      result.current.sendMessage('hello');
+    });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(capturedSignal?.aborted).toBe(false);
+
+    act(() => {
+      result.current.stopStreaming();
+    });
+
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(result.current.isStreaming).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests**
+
+```bash
+pnpm test:run src/hooks/useChat.test.ts
+```
+
+Expected: ALL 4 new tests pass on the first run (the existing hook code already implements the streaming, tool sequencing, and stopStreaming behavior — these are regression-codification tests, not behavior-change tests). All other tests in the file still pass.
+
+If any new test fails:
+- For the streaming tests: the `streamResponse` helper may need adjustment for happy-dom's `ReadableStream`. Check that `Response` exposes `.body.getReader()` correctly.
+- For the abort test: confirm `stopStreaming()` is exposed in the hook's return — verified via `useChat.ts:300-303`.
+
+- [ ] **Step 3: Run the full gate set**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm test:run
+```
+
+Expected: all silent. Test count: 176 → 180 across 20 files (+4 in useChat.test.ts).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useChat.test.ts
+git commit -m "$(cat <<'EOF'
+test(use-chat): codify streaming + tool sequencing + stopStreaming abort
+
+The existing useChat.test.ts already covered the D-3 4xx-error path and the
+D-4 switchConversation/deleteConversation/clearAllConversations abort
+paths. The remaining gap was the sendMessage streaming itself: text-delta
+accumulation, tool-call/tool-result/tool-error chunk wiring, and the
+in-input stopStreaming() abort.
+
+Add 4 tests using global.fetch with hand-built ReadableStream chunks
+(matching the existing 4xx integration-test pattern) so each invariant has
+a regression harness without duplicating the abort coverage already in
+'useChat abort behavior'.
+
+Closes #12
+EOF
+)"
+```
+
+---
+
+## Task 5: #14 U-5 — Sidebar conversation-title tooltip (no test, single attribute)
+
+**Files:**
+- Modify: `src/components/Sidebar.tsx`
+
+**Pattern:** Static attribute addition. Native HTML `title` attribute produces a browser-default tooltip. No new tests — the existing Sidebar tests still cover the relevant render paths.
+
+- [ ] **Step 1: Add `title` attribute to the static-title `<span>`**
+
+Open `src/components/Sidebar.tsx`. Find the per-row JSX block. The static-title `<span>` is the one rendered when `editingId !== conv.id`:
+
+```tsx
+              ) : (
+                <span className="flex-1 truncate">{conv.title}</span>
+              )}
+```
+
+Change to:
+
+```tsx
+              ) : (
+                <span className="flex-1 truncate" title={conv.title}>{conv.title}</span>
+              )}
+```
+
+That is the only change. The `title` attribute is a standard HTML attribute — every browser shows a tooltip with the attribute's value on hover (~1.5s delay), and screen readers announce it as the element's accessible description.
+
+- [ ] **Step 2: Run the gate set**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm test:run
+```
+
+Expected: all silent. Test count: 180/180 across 20 files (unchanged).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Sidebar.tsx
+git commit -m "$(cat <<'EOF'
+fix(sidebar): show full conversation title on hover via native tooltip
+
+Conversation rows truncate at ~20 chars, making it hard to distinguish
+several "USDC..." chats. Add the native HTML title attribute to the static-
+title span so hovering surfaces the full title — accessible to screen
+readers, zero JS, browser-default delay (~1.5s).
+
+A custom-styled tooltip matching kami-surface would look more polished but
+costs ~30-60 lines and a positioning library; defer that to a future
+sprint.
+
+Closes #14
+EOF
+)"
+```
+
+---
+
+## Task 6: #15 U-7 — Empty-state cards clickable (TDD)
+
+**Files:**
+- Create: `src/components/EmptyState.test.tsx`
+- Modify: `src/components/EmptyState.tsx`
+- Modify: `src/components/ChatPanel.tsx`
+
+**Pattern:** TDD red → green. Add the failing tests first, run to confirm fail, implement the props/handlers, run to pass.
+
+- [ ] **Step 1: Create `src/components/EmptyState.test.tsx` with 5 failing tests**
+
+Create the new file:
+
+```typescript
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@solana/wallet-adapter-react', () => ({
+  useWallet: () => ({ connected: false, connecting: false, wallets: [] }),
+}));
+
+vi.mock('@solana/wallet-adapter-react-ui', () => ({
+  useWalletModal: () => ({ setVisible: vi.fn() }),
+}));
+
+import EmptyState from './EmptyState';
+
+describe('EmptyState feature cards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all 4 feature card titles', () => {
+    render(<EmptyState onSend={vi.fn()} />);
+    expect(screen.getByText('Live Yields')).toBeInTheDocument();
+    expect(screen.getByText('Build & Sign')).toBeInTheDocument();
+    expect(screen.getByText('Portfolio')).toBeInTheDocument();
+    expect(screen.getByText('Health Sim')).toBeInTheDocument();
+  });
+
+  it('fires the Live Yields query on click', () => {
+    const onSend = vi.fn();
+    render(<EmptyState onSend={onSend} />);
+    fireEvent.click(screen.getByText('Live Yields').closest('button')!);
+    expect(onSend).toHaveBeenCalledWith('What are the best Kamino yields right now?');
+  });
+
+  it('fires the Build & Sign query on click', () => {
+    const onSend = vi.fn();
+    render(<EmptyState onSend={onSend} />);
+    fireEvent.click(screen.getByText('Build & Sign').closest('button')!);
+    expect(onSend).toHaveBeenCalledWith('Show me a 5 USDC deposit example');
+  });
+
+  it('fires the Portfolio query on click', () => {
+    const onSend = vi.fn();
+    render(<EmptyState onSend={onSend} />);
+    fireEvent.click(screen.getByText('Portfolio').closest('button')!);
+    expect(onSend).toHaveBeenCalledWith('Show me my Kamino portfolio');
+  });
+
+  it('fires the Health Sim query on click', () => {
+    const onSend = vi.fn();
+    render(<EmptyState onSend={onSend} />);
+    fireEvent.click(screen.getByText('Health Sim').closest('button')!);
+    expect(onSend).toHaveBeenCalledWith('Will my borrow position liquidate at SOL $50?');
+  });
+});
+```
+
+Note: the cards become `<button>` elements (semantic + keyboard-focusable), so the test queries the closest button ancestor of each title.
+
+- [ ] **Step 2: Run the failing tests**
+
+```bash
+pnpm test:run src/components/EmptyState.test.tsx
+```
+
+Expected: TypeScript error (EmptyState doesn't accept `onSend` prop) OR test failure (cards aren't clickable). 5 of 5 fail.
+
+- [ ] **Step 3: Update `src/components/EmptyState.tsx`**
+
+Open `src/components/EmptyState.tsx`. Replace the entire component definition:
+
+**Edit A:** Update the props signature. Current line 21 reads:
+
+```typescript
+export default function EmptyState() {
+```
+
+Change to:
+
+```typescript
+interface Props {
+  onSend: (msg: string) => void;
+}
+
+export default function EmptyState({ onSend }: Props) {
+```
+
+**Edit B:** Update the cards array structure. Current cards definition at lines 50-67 reads:
+
+```tsx
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-left mb-6">
+          {(
+            [
+              { Icon: TrendingUp, title: 'Live Yields', desc: 'Find best APYs on Kamino' },
+              { Icon: ArrowLeftRight, title: 'Build & Sign', desc: 'Deposit, borrow, withdraw, repay' },
+              { Icon: Wallet, title: 'Portfolio', desc: 'Your Kamino positions + APY' },
+              { Icon: ShieldCheck, title: 'Health Sim', desc: 'Liquidation-risk checks' },
+            ] satisfies Array<{ Icon: LucideIcon; title: string; desc: string }>
+          ).map(({ Icon, title, desc }) => (
+            <div
+              key={title}
+              className="p-3 rounded-xl border border-kami-border bg-kami-surface/50 hover:bg-kami-surface transition-colors"
+            >
+              <Icon className="w-5 h-5 text-kami-accent mb-2" aria-hidden="true" />
+              <div className="text-sm font-medium text-white">{title}</div>
+              <div className="text-xs text-kami-muted">{desc}</div>
+            </div>
+          ))}
+        </div>
+```
+
+Replace with:
+
+```tsx
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-left mb-6">
+          {(
+            [
+              {
+                Icon: TrendingUp,
+                title: 'Live Yields',
+                desc: 'Find best APYs on Kamino',
+                query: 'What are the best Kamino yields right now?',
+              },
+              {
+                Icon: ArrowLeftRight,
+                title: 'Build & Sign',
+                desc: 'Deposit, borrow, withdraw, repay',
+                query: 'Show me a 5 USDC deposit example',
+              },
+              {
+                Icon: Wallet,
+                title: 'Portfolio',
+                desc: 'Your Kamino positions + APY',
+                query: 'Show me my Kamino portfolio',
+              },
+              {
+                Icon: ShieldCheck,
+                title: 'Health Sim',
+                desc: 'Liquidation-risk checks',
+                query: 'Will my borrow position liquidate at SOL $50?',
+              },
+            ] satisfies Array<{ Icon: LucideIcon; title: string; desc: string; query: string }>
+          ).map(({ Icon, title, desc, query }) => (
+            <button
+              key={title}
+              type="button"
+              onClick={() => onSend(query)}
+              className="text-left p-3 rounded-xl border border-kami-border bg-kami-surface/50 hover:bg-kami-surface transition-colors cursor-pointer"
+            >
+              <Icon className="w-5 h-5 text-kami-accent mb-2" aria-hidden="true" />
+              <div className="text-sm font-medium text-white">{title}</div>
+              <div className="text-xs text-kami-muted">{desc}</div>
+            </button>
+          ))}
+        </div>
+```
+
+Key changes:
+- `<div>` → `<button type="button">` for semantic clickability + keyboard focus
+- `cursor-pointer` class added (explicit hand cursor)
+- `text-left` retained on the button (button default is center-aligned)
+- Each card has a `query` field defining what fires on click
+- `onClick={() => onSend(query)}` wires the click handler
+
+- [ ] **Step 4: Update `src/components/ChatPanel.tsx`**
+
+Open `src/components/ChatPanel.tsx`. Find the `<EmptyState />` render (currently around line 69 — a self-closing `<EmptyState />` with no props).
+
+Current:
+```tsx
+      ) : (
+        <EmptyState />
+      )}
+```
+
+Change to:
+```tsx
+      ) : (
+        <EmptyState onSend={handleSend} />
+      )}
+```
+
+`handleSend` is the existing function in `ChatPanel.tsx` that wraps `onSend` with `publicKey?.toBase58() ?? null` (line 26-28).
+
+- [ ] **Step 5: Run the tests to confirm they pass**
+
+```bash
+pnpm test:run src/components/EmptyState.test.tsx
+```
+
+Expected: 5/5 pass.
+
+- [ ] **Step 6: Run the full gate set**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm test:run
+```
+
+Expected: all silent. Test count: 180 → 185 across 20 → 21 files (`EmptyState.test.tsx` is new with 5 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/EmptyState.tsx src/components/EmptyState.test.tsx src/components/ChatPanel.tsx
+git commit -m "$(cat <<'EOF'
+feat(empty-state): make feature cards clickable and fire representative queries
+
+The 4 cards on the welcome screen — Live Yields, Build & Sign, Portfolio,
+Health Sim — looked clickable (rounded corners, lucide-react icons, hover
+state) but did nothing. Fresh users expected clicking "Live Yields" to
+auto-fire a relevant query.
+
+Convert each card from a <div> to a <button type="button"> with an
+onClick that fires its representative query through a new onSend prop.
+ChatPanel passes its existing handleSend (which wraps onSend with the
+wallet publicKey). cursor-pointer class makes the affordance explicit.
+
+  Live Yields → "What are the best Kamino yields right now?"
+  Build & Sign → "Show me a 5 USDC deposit example"
+  Portfolio → "Show me my Kamino portfolio"
+  Health Sim → "Will my borrow position liquidate at SOL $50?"
+
+5 new tests cover the per-card click + a smoke test for all 4 titles
+rendering.
+
+Closes #15
+EOF
+)"
+```
+
+---
+
+## Final verification — full PR readiness
+
+- [ ] **Step 1: Verify the 7-commit shape**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected output (commit hashes will differ):
+```
+<hash> feat(empty-state): make feature cards clickable and fire representative queries
+<hash> fix(sidebar): show full conversation title on hover via native tooltip
+<hash> test(use-chat): codify streaming + tool sequencing + stopStreaming abort
+<hash> fix(rpc-guards): switch from denylist to allowlist
+<hash> fix(ratelimit): randomize dev identifier per process
+<hash> fix(chat): use absolute path for /api/chat fetch
+<hash> docs(spec): add Sprint 4.3 P1 cluster design
+```
+
+(7 commits total: 1 spec + 6 implementation.)
+
+- [ ] **Step 2: Run the full gate set one more time**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm test:run
+```
+
+Expected: silent / silent / 185 tests passing across 21 files.
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git push -u origin feat/p1-cluster
+gh pr create --title "feat: P1 cluster — server hygiene + UI polish + useChat test expansion" --body "$(cat <<'EOF'
+## Summary
+
+Sprint 4.3 — closes the remaining 6 P1 items in the \`qa-2026-04-26\` backlog. After this PR merges, umbrella issue #3 also closes (entire 2026-04-26 baseline-QA backlog cleared).
+
+Six sub-changes, one commit per logical change:
+
+- **#9 D-5 (commit 1):** \`fetch('api/chat')\` → \`fetch('/api/chat')\`. Single-character fix; relative form would break under sub-path routing.
+- **#10 D-9 (commit 2):** Cache \`'dev-' + crypto.randomUUID()\` at module load; return it from \`identify()\` outside production. Production fail-closed behavior (empty string when no IP) unchanged. Stops a dev build accidentally pointed at real Upstash from sharing the \`'anonymous'\` bucket with every other dev caller.
+- **#11 D-10 (commit 3):** Replace \`DENIED_METHODS\` denylist with \`ALLOWED_METHODS\` allowlist of the 10 RPC methods Kami actually calls. Rename \`deniedMethodIn\` → \`disallowedMethodIn\`. Adds a membership-test that codifies the contract. Manual smoke against \`pnpm dev\` confirmed all wallet-sign + portfolio paths return 200.
+- **#12 D-11 (commit 4):** Add 4 streaming/sequencing/abort tests to \`useChat.test.ts\`. Targets the actual coverage gap — D-3 + D-4 regression cases were already covered in earlier sprints; this commit codifies text-delta accumulation, tool-call/result/error chunk wiring, and the in-input \`stopStreaming\` abort path.
+- **#14 U-5 (commit 5):** Add \`title={conv.title}\` to the static-title \`<span>\` in Sidebar. Native HTML tooltip on hover. Accessible, zero JS.
+- **#15 U-7 (commit 6):** Convert the 4 empty-state cards from \`<div>\` to \`<button>\` with \`onClick\` firing each card's representative query through a new \`onSend\` prop. \`cursor-pointer\` makes the affordance explicit. ChatPanel passes its existing \`handleSend\` (wallet-aware).
+
+## Test plan
+
+- 9 new tests across 4 test files (\`server/ratelimit.test.ts\` +0 net (1 deleted, 1 added), \`server/rpc-guards.test.ts\` +1, \`src/hooks/useChat.test.ts\` +4, \`src/components/EmptyState.test.tsx\` NEW +5)
+- \`pnpm test:run\`: 175 → 185 across 20 → 21 files
+- TDD red → green on tasks 2, 4, 6
+- [ ] Manual smoke post-deploy: submit chat query → confirm 200 from \`/api/chat\` (#9)
+- [ ] Manual smoke post-deploy: \`X-RateLimit-*\` headers show \`dev-\` identifier in dev / real IP in prod (#10)
+- [ ] Manual smoke post-deploy: wallet-sign a deposit → no \`/api/rpc\` 403s (#11)
+- [ ] Manual smoke post-deploy: hover sidebar row → native tooltip with full title (#14)
+- [ ] Manual smoke post-deploy: click each empty-state card → matching query sent (#15)
+
+## Closes
+
+Closes #9
+Closes #10
+Closes #11
+Closes #12
+Closes #14
+Closes #15
+EOF
+)"
+```
+
+- [ ] **Step 4: Watch CI**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: green across `test`, `mirror-gitlab`, and Vercel.
+
+- [ ] **Step 5: After merge — close umbrella issue #3 manually**
+
+After the PR merges, all P1 children (#9 #10 #11 #12 #14 #15) auto-close via the `Closes` directives. The umbrella issue #3 remains OPEN even after all children close — GitHub doesn't auto-close umbrella issues based on child state.
+
+Tick the umbrella's last 6 P1 boxes, then close the issue:
+
+```bash
+# Edit the umbrella body to tick #9 #10 #11 #12 #14 #15 with PR-merge SHA
+gh issue view 3 --json body --jq .body > /tmp/umbrella-body.md
+# Use sed or Edit to tick each `- [ ] #N` line to `- [x] #N ... — PR #<N> merged at <SHA>`
+gh issue edit 3 --body-file /tmp/umbrella-body.md
+
+# Then close the umbrella with a final comment
+gh issue close 3 --comment "All 27 child issues from the 2026-04-26 baseline-QA run are now closed. Sprint 4.3 (PR #<N>) closed the final P1 cluster. Closing this umbrella — future QA runs will spawn their own."
+```
+
+(Replace `<N>` with the actual PR number after merge. The exact body-tick edit pattern matches what was done after Sprint 4.2b for the umbrella's P2 row.)
+
+---
+
+## Notes for the executing engineer
+
+- **`pnpm exec tsc -b` does NOT validate `server/tsconfig.json`.** Always run all 3 typecheck commands separately. (Memory: `tsc-b-skips-server-tsconfig.md`.) Tasks 2 and 3 touch server code, so this matters.
+- **`Array.prototype.at()` does NOT work in `src/`** (ES2020 lib target). Use `arr[arr.length - 1]`. Not relevant to this sprint — flagged for awareness.
+- **HEREDOC commit messages** per global CLAUDE.md. No AI attribution in any commit, comment, or PR body.
+- **One commit per logical change.** Each task ends in exactly one commit. If a task fails the gate set, fix and re-stage before committing — do NOT amend the prior task's commit. Code-review fix commits ship in the same PR (Sprint 4.2 precedent).
+- **happy-dom (NOT jsdom)** is the Vitest test environment. `vi.spyOn(window, 'confirm')` would throw — direct property assignment + module-level capture + afterEach restore is the failure-safe pattern. Not relevant to this sprint's tests, but noted for any future expansion.
+- **Task 3 manual smoke is mandatory.** The allowlist may be missing a method the app legitimately uses. Don't skip the `pnpm dev` smoke before commit — false-negative regressions in production cost more than 5 minutes of manual testing.
+- **Task 4's tests should pass on first run.** They are regression-codification tests for already-implemented behavior, NOT TDD-driving-new-behavior tests. If any new test fails, debug the test (often the `streamResponse` helper or the SSE chunk format) before assuming the hook code has a bug.
+- **Task 6's accessibility upgrade (`<div>` → `<button>`) is intentional.** Buttons get keyboard focus and Enter/Space activation for free. The wallet-connect button below the cards is unchanged.

--- a/docs/superpowers/specs/2026-04-28-p1-cluster-design.md
+++ b/docs/superpowers/specs/2026-04-28-p1-cluster-design.md
@@ -1,0 +1,242 @@
+# Sprint 4.3 — P1 cluster: server hygiene + UI polish + useChat test expansion
+
+**Date:** 2026-04-28
+**Issues:**
+- [#9 — D-5 Drop relative `fetch('api/chat')` for `/api/chat`](https://github.com/RECTOR-LABS/kami/issues/9)
+- [#10 — D-9 Random per-process token in dev to avoid 'anonymous' shared bucket](https://github.com/RECTOR-LABS/kami/issues/10)
+- [#11 — D-10 Switch RPC guard from denylist to allowlist](https://github.com/RECTOR-LABS/kami/issues/11)
+- [#12 — D-11 Expand `useChat.test.ts` to cover streaming + abort + D-3/D-4 regressions](https://github.com/RECTOR-LABS/kami/issues/12)
+- [#14 — U-5 Sidebar conversation-title tooltip on hover](https://github.com/RECTOR-LABS/kami/issues/14)
+- [#15 — U-7 Empty-state feature cards: make clickable or downgrade to badges](https://github.com/RECTOR-LABS/kami/issues/15)
+
+**Priority:** P1 (`qa-2026-04-26`)
+**Sprint:** 4.3 (priority-based cluster — final P1 sweep, closes the entire 2026-04-26 QA backlog)
+**Estimate:** ~6-10h walltime; per-item range <1h to 4h+
+**Branch:** `feat/p1-cluster`
+
+---
+
+## Problem
+
+Six remaining P1 items in the QA backlog after Sprints 4.1 (P3 trivial sweep), 4.2a (P2 server hygiene), and 4.2b (P2 UI features) closed the lower-priority and the P2 sub-clusters. The six items split into three sub-themes that share the same time scale (most under 2h each):
+
+- **Server hygiene** (#9 #10 #11) — three small server-side robustness improvements: a relative-URL fetch path with breakage potential under sub-path routing; a shared `'anonymous'` rate-limit bucket in dev environments; an unbounded RPC denylist that grows unbounded as Solana adds methods.
+- **UI polish** (#14 #15) — two discoverability gaps in the sidebar and empty state: truncated chat titles with no tooltip; empty-state feature cards that visually invite a click but currently do nothing.
+- **Test expansion** (#12) — the broader streaming/abort/error-handling coverage gap on `useChat.ts` that was first flagged in the baseline QA report. C-1 (Sprint 1.1) added `mapToolResultStatus` unit tests; the hook's hot reducer-style state is otherwise still uncovered.
+
+None of these are demo-blocking for the Eitherway-Kamino bounty. Sprint 4.3 closes them so the backlog ledger is clean before the bounty submission, and so post-merge the umbrella tracking issue (#3) can also close.
+
+## Scope
+
+**In scope (6 commits, single PR on `feat/p1-cluster`):**
+
+### #9 — Drop relative fetch path (commit 1)
+
+`src/hooks/useChat.ts:182` — change `fetch('api/chat', ...)` to `fetch('/api/chat', ...)`. Single-character fix. The relative form resolves against the current document URL and breaks if the SPA is ever served from a non-root sub-path or if `react-router` ever pushes the URL into a sub-segment without a trailing slash. Absolute path is the standard.
+
+No new test required — the path change is covered by every existing integration path that hits `/api/chat`.
+
+### #10 — Random per-process token in dev (commit 2)
+
+`server/ratelimit.ts:65` — replace the `'anonymous'` literal returned by `identify()` in non-production with a randomized per-process token cached at module load: `'dev-' + crypto.randomUUID()`. Production behavior unchanged (still resolves real IP / wallet / session identifiers).
+
+The motivation: if a developer accidentally points a local dev build at the real Upstash, every request from that build shares the `anonymous` bucket — a single curl loop exhausts it for the whole session. A per-process random token ensures each dev process has its own bucket without leaking real identity.
+
+Add a small unit test confirming `identify()` returns a `dev-`-prefixed UUID-shaped string when `NODE_ENV !== 'production'` and no real identifier is provided.
+
+### #11 — RPC allowlist (commit 3)
+
+`server/rpc-guards.ts` — replace the `DENIED_METHODS` denylist with an `ALLOWED_METHODS` allowlist. Rename the function `deniedMethodIn(payload)` → `disallowedMethodIn(payload)` (returns the method name when it is NOT in the allowlist; the call site in `api/rpc.ts` reads "if disallowed, 403"). Update the existing `server/rpc-guards.test.ts` to flip semantics: known-good method passes, arbitrary method (e.g. `'getProgramAccounts'`) is now caught.
+
+**Initial allowlist (implementer verifies + extends as needed via grep + smoke test before commit):**
+
+- `getHealth` — heartbeat / readiness checks
+- `getLatestBlockhash` — transaction construction
+- `getBalance` — wallet balance reads
+- `getAccountInfo` — single-account reads
+- `getMultipleAccounts` — batch reads (Kamino uses this)
+- `simulateTransaction` — preflight simulation
+- `sendTransaction` — wallet broadcast
+- `getSignatureStatuses` — confirmation polling (used by `SignTransactionCard.pollSignatureStatus`)
+- `getBlockHeight` — confirmation timeout (used by `pollSignatureStatus`)
+- `getMinimumBalanceForRentExemption` — rent calculations
+
+The implementer must run `pnpm dev`, exercise: wallet connect, sign a deposit transaction (devnet OK), confirm it on-chain, and verify no `/api/rpc` 403s appear in the browser console. If any new method shows up that the app legitimately needs, add it to the allowlist before committing.
+
+The Day 14 (Sprint 4.2a) `oversizedParamsIn` shallow-check NOTE in `server/rpc-guards.ts:33-39` stays — that comment is about a different concern (nested-array params) and is unaffected by the allowlist switch.
+
+### #12 — useChat.test.ts streaming + abort + regression coverage (commit 4)
+
+`src/hooks/useChat.test.ts` — extend with `renderHook` + a stubbed `global.fetch` yielding canned SSE chunks. Sprint 4.2b already added the `aborts in-flight stream when clearAllConversations is called` test using this pattern; reuse it.
+
+**New describe blocks (~6-8 tests total):**
+
+- `useChat sendMessage streaming` — stub fetch returning an SSE stream with text-delta chunks, assert that `activeConversation.messages[last].content` accumulates correctly. Verify the assistant message moves from empty → partial → complete in the right order.
+- `useChat sendMessage tool sequencing` — stub fetch with chunks containing `parsed.toolCall`, `parsed.toolResult`, `parsed.toolError`. Assert that `messages[last].toolCalls` updates (call → done | error | wallet-required) per the `mapToolResultStatus` contract. The status mapping itself is already unit-tested; this verifies the wiring inside `commitToolCalls`.
+- `useChat sendMessage abort during streaming` — start a `sendMessage`, abort via `stopStreaming` mid-stream, assert `isStreaming` becomes false and the assistant message stays at whatever was accumulated (no error string overwrites in-progress content).
+- `useChat D-3 regression` — stub fetch with a 429 response (rate-limited), assert the assistant message renders the formatted error string from `formatChatError`. (`formatChatError` is already unit-tested in isolation; this confirms the hook calls it on the right path.)
+- `useChat D-4 regression — switchConversation aborts in-flight stream` — start `sendMessage`, switch conversation mid-stream, assert the captured `AbortSignal` is aborted.
+- `useChat D-4 regression — deleteConversation aborts in-flight stream` — same pattern as above for `deleteConversation` of the active conversation.
+- (optional, if straightforward) `useChat D-4 regression — deleteConversation of NON-active does NOT abort` — confirms the existing guard at `useChat.ts:102-104`.
+
+The `useChat clearAllConversations` describe block already has the abort regression (added in Sprint 4.2b round-1 fix). Don't duplicate it — this commit's tests are about `sendMessage`, `switchConversation`, and `deleteConversation`.
+
+### #14 — Sidebar tooltip (commit 5)
+
+`src/components/Sidebar.tsx` — add a `title={conv.title}` attribute to the existing `<span className="flex-1 truncate">` that renders the chat title in the non-edit branch. The native HTML `title` attribute produces a browser-default tooltip (~1.5s delay) on hover, accessible to screen readers, no JS required.
+
+Edit-mode branch (the `<input>`) keeps its own `aria-label` from Sprint 4.2b — no change there.
+
+No new test required — this is a static attribute addition. The existing Sidebar tests still cover the relevant render paths.
+
+### #15 — Empty-state cards clickable (commit 6)
+
+`src/components/EmptyState.tsx` + `src/components/ChatPanel.tsx`.
+
+**Wiring:** Add an `onSend: (msg: string) => void` prop to `EmptyState`. In `ChatPanel`, pass `handleSend` (which already wraps `onSend` with `publicKey`) as `<EmptyState onSend={handleSend} />`. The `EmptyState` component is rendered only when `hasMessages === false`, so the wiring is direct.
+
+**Card behavior:** Each card gets an `onClick` that fires its representative query through `onSend`. The cards already have `hover:bg-kami-surface` (which hints at clickability); add `cursor-pointer` to make the affordance explicit.
+
+**Card → query mapping:**
+
+| Card title | Query fired |
+|---|---|
+| Live Yields | `What are the best Kamino yields right now?` |
+| Build & Sign | `Show me a 5 USDC deposit example` |
+| Portfolio | `Show me my Kamino portfolio` |
+| Health Sim | `Will my borrow position liquidate at SOL $50?` |
+
+**Tests (NEW file `src/components/EmptyState.test.tsx`):**
+
+- 4 tests, one per card: render `<EmptyState onSend={mockFn} />`, click the card, assert `mockFn` called with the expected query string.
+- 1 smoke test: render `<EmptyState onSend={mockFn} />`, assert all 4 card titles appear.
+
+The wallet-connect button already in `EmptyState` keeps its existing handlers — independent from the cards.
+
+**Out of scope** (explicitly deferred):
+
+- **Custom-styled tooltip for #14.** Native `title` is the smallest correct fix. A custom positioned tooltip matching `bg-kami-surface border-kami-border` would add ~30-60 lines and require Headless UI / Radix or similar. Defer until a wider tooltip pattern lands.
+- **Hover affordance polish on EmptyState cards.** The `hover:bg-kami-surface` is the current pattern; sprint adds `cursor-pointer` but does not change visual hover treatment otherwise. A more pronounced hover (lift + shadow + border-glow) is cosmetic; defer.
+- **Accessibility upgrade on `EmptyState` cards.** Plain `<div role="button">` would be more correct than relying on `<div onClick>`; the four cards as currently rendered are not keyboard-focusable. Add `tabIndex={0}` + `onKeyDown` Enter handler if the bounty's a11y review surfaces this; otherwise defer.
+- **`useChat.test.ts` branch coverage of `JSON.parse(data)` failure path.** The hook silently continues on `SyntaxError`; testing this would require carefully malformed SSE chunks. Defer — behavioral coverage is the goal, not branch coverage.
+- **#11 RPC allowlist drift detection.** A future Solana method that the app legitimately needs to call would be silently 403'd until someone notices and updates the allowlist. Mitigation in this sprint: the implementer's manual smoke covers the known paths. A separate sprint could add a synthetic monitor or a client-side "method denied" toast.
+
+## Architecture
+
+```
+src/hooks/
+  useChat.ts                                    server/
+  ──────────                                    ─────
+  Line 163 (commit 1):                          ratelimit.ts (commit 2)
+    - fetch('api/chat', ...)                    ───────────
+      → fetch('/api/chat', ...)                 - At module load, cache
+                                                  DEV_TOKEN = 'dev-' +
+  useChat.test.ts (commit 4)                      crypto.randomUUID()
+  ────────────────                              - In identify(), if
+  Append 3 new describe blocks:                   NODE_ENV !== 'production'
+    + sendMessage streaming                       and no real id, return
+    + sendMessage tool sequencing                 DEV_TOKEN
+    + sendMessage abort during streaming        - Test: identify() returns
+    + D-3 regression (4xx)                        dev-prefixed UUID-shaped
+    + D-4 regression (switch + delete)            string in non-prod
+
+src/components/                                 server/rpc-guards.ts (commit 3)
+  ─────────                                     ──────────────────
+  Sidebar.tsx (commit 5):                       - DENIED_METHODS → ALLOWED_METHODS
+    + title={conv.title} on the                 - deniedMethodIn → disallowedMethodIn
+      static-title <span>                       - Returns method name iff
+                                                  !ALLOWED_METHODS.has(method)
+  EmptyState.tsx (commit 6):                    - oversizedParamsIn unchanged
+    + onSend prop
+    + onClick on each of 4 cards                rpc-guards.test.ts (commit 3)
+    + cursor-pointer class                      ────────────────
+                                                - Flip 1-2 existing tests
+  ChatPanel.tsx (commit 6):                       (known-good passes;
+    + <EmptyState onSend={handleSend} />          arbitrary method 403s)
+                                                - Add 1 allowlist-membership test
+  EmptyState.test.tsx (commit 6, NEW):
+    + 4 tests (one per card click)
+    + 1 smoke test
+```
+
+### Key design decisions
+
+1. **Single PR with 6 commits.** All items are small (most <1-2h), well-bounded to one or two files, and don't touch each other's code. A sub-split into 4.3a/b/c was considered (matches Sprint 4.2 precedent) but rejected because (a) opus cluster review handles 6 commits fine — Sprint 4.2a's PR had 9 commits, 4.2b's had 5 — and (b) one PR-cycle vs. three saves ~1-2h of overhead. Sprint 4.2's split was justified by the deep theme divergence (server vs. UI); Sprint 4.3's items, while spanning three themes, are each so small that the divergence cost is minimal.
+
+2. **Native `title` attribute over custom tooltip for #14.** The simplest fix that works on every browser, every screen reader, and every input modality. Custom tooltips would match Kami's dark theme better but cost 30-60 lines + a positioning library or careful CSS. Defer the polish to a future sprint.
+
+3. **Clickable cards over downgraded badges for #15.** The existing visual already invites a click (cards have hover state, rounded corners, lucide-react icons); making them actually fire queries respects the user's expectation. Downgrading to badges would be a regression — fewer demo-friendly entry points before bounty.
+
+4. **Card-to-query mapping is hard-coded inline, not extracted.** Four entries; YAGNI applies. If the empty state grows to ~10 cards or if cards become user-configurable, extract then.
+
+5. **#11 allowlist starting set, implementer verifies.** Static enumeration via `grep` is unreliable because some RPC methods are called indirectly through `@solana/wallet-adapter-react`'s wallet adapter or through `Connection` instance methods. The starting list above covers the known direct paths; the implementer runs `pnpm dev` + a wallet-sign smoke test before commit and adds any method that 403s.
+
+6. **#12 D-11 test scope is behavioral, not branch coverage.** The goal is "does the hook produce the right state on the right inputs?" — not "does every line execute?" Specifically out of scope: the `JSON.parse` syntax-error catch arm (existence verified by code reading; testing would require malformed SSE chunks); the inner `for (const line of lines)` early-`break` on `[DONE]` (covered indirectly by stream-completion tests).
+
+7. **No new files outside `EmptyState.test.tsx`.** Item 6's component test file is the only new file. Items 1-5 modify existing files only.
+
+8. **One commit per logical change, six commits total.** Per project rule. Code-review fix commits ship in the same PR (Sprint 4.2 precedent).
+
+## Test plan
+
+| Coverage | Where | New tests |
+|---|---|---|
+| #10 D-9 dev-token returns dev-prefixed UUID-shape | `server/ratelimit.test.ts` (extend) | +1 |
+| #11 D-10 known-good method passes | `server/rpc-guards.test.ts` (flip semantics) | edits to existing |
+| #11 D-10 arbitrary method 403s | `server/rpc-guards.test.ts` (flip semantics) | edits to existing |
+| #11 D-10 allowlist set assertion | `server/rpc-guards.test.ts` | +1 |
+| #12 D-11 sendMessage streaming text-delta | `src/hooks/useChat.test.ts` (extend) | +1 |
+| #12 D-11 sendMessage tool sequencing | `src/hooks/useChat.test.ts` | +1 |
+| #12 D-11 sendMessage abort during streaming | `src/hooks/useChat.test.ts` | +1 |
+| #12 D-11 D-3 regression (4xx error rendering) | `src/hooks/useChat.test.ts` | +1 |
+| #12 D-11 D-4 switchConversation aborts | `src/hooks/useChat.test.ts` | +1 |
+| #12 D-11 D-4 deleteConversation of active aborts | `src/hooks/useChat.test.ts` | +1 |
+| #12 D-11 D-4 deleteConversation of non-active does NOT abort | `src/hooks/useChat.test.ts` | +1 |
+| #15 U-7 each card click fires onSend with expected query | `src/components/EmptyState.test.tsx` (NEW) | +4 |
+| #15 U-7 cards render (smoke) | `src/components/EmptyState.test.tsx` | +1 |
+
+**Test count delta:** 175 → ~189 across 20 → 21 files. (`EmptyState.test.tsx` is new; `server/ratelimit.test.ts`, `server/rpc-guards.test.ts`, `src/hooks/useChat.test.ts` all extended.)
+
+**Validation gates** (per CLAUDE.md, run after every commit):
+- `pnpm exec tsc --noEmit` — silent (client)
+- `pnpm exec tsc -p server/tsconfig.json --noEmit` — silent (server)
+- `pnpm test:run` — green, count matches commit's expected delta
+
+**Manual smoke (post-deploy):**
+- Submit a chat query → confirm `/api/chat` (with absolute path) is hit (#9)
+- Open dev tools → trigger a request → confirm `X-RateLimit-*` headers show a `dev-`-prefixed identifier in dev (#10)
+- Wallet-sign a deposit transaction → confirm no `/api/rpc` 403s in browser console (#11)
+- Hover any sidebar conversation row → confirm browser-default tooltip with full title appears (#14)
+- On welcome screen → click each of the 4 cards → confirm the matching query is sent (#15)
+
+## Risks
+
+**Low-to-medium overall.** Item #11 is the only item with non-trivial regression potential.
+
+- **#11 allowlist false-negative regression.** If a method the app legitimately uses is missing from the allowlist, that path 403s in production silently (no crash, but the call fails). Mitigation: implementer's `pnpm dev` smoke before commit covers the known paths; the existing CI includes the rpc-guards tests with flipped semantics; production rollout is gradual via Vercel's rolling deploy. If a previously-working flow breaks post-deploy, a one-line allowlist addition + redeploy resolves it (~5 min).
+
+- **#10 dev-token entropy.** `crypto.randomUUID()` is part of the global Crypto API in Node 19+. Kami's package.json uses Node 24 LTS (Vercel default), so this is safe. If the test environment differs (happy-dom in Vitest), `crypto.randomUUID` is also defined — verified from prior Sprint 4.2b experience.
+
+- **#12 D-11 walltime overrun.** Estimated 4h+. SSE-chunk fixtures may take longer than expected if mocking the `body.getReader()` interface gets fiddly. Mitigation: time-box each test to ~30min; if a test gets stuck, ship what's stable and file a follow-up issue rather than blocking the sprint. Worst case: this sprint becomes 5 commits + a deferred D-11.
+
+- **#15 wiring regression.** The `EmptyState` component currently has a wallet-connect button and a "Use another Solana wallet" button. Adding `onSend` doesn't touch them. The existing `useWallet` and `useWalletModal` hooks remain. No interference expected.
+
+- **#14 native tooltip styling.** Browser-default tooltips are gray, ~1.5s delay, can't be styled. Acceptable trade-off — aesthetics are not the goal. If RECTOR later wants the polish, file as a follow-up.
+
+## Acceptance criteria
+
+- [ ] All 6 commits land on `feat/p1-cluster`, one per logical change.
+- [ ] PR body lists `Closes #9`, `Closes #10`, `Closes #11`, `Closes #12`, `Closes #14`, `Closes #15`.
+- [ ] All 3 typecheck commands silent on each commit.
+- [ ] `pnpm test:run` shows ~189/189 across ~21 files at branch tip.
+- [ ] Cluster reviewer (`opus`) returns SHIP IT with 0 Critical / 0 Important.
+- [ ] After PR merge, `gh issue list --label qa-2026-04-26 --state open --limit 30` returns 0-1 (umbrella #3 closes when all child issues close, OR is closed manually).
+- [ ] Umbrella issue #3's P1 row fully ticked.
+- [ ] No AI attribution in commit messages, PR body, comments, or any added code.
+
+## Out-of-band notes
+
+- **Sprint 4.2b's bonus abort test** (`useChat clearAllConversations` describe block, added in commit `ff3702b`) covered the abort path for `clearAllConversations`. This sprint covers the abort path for `switchConversation` and `deleteConversation` separately under `useChat sendMessage / D-4 regression`. The abort-via-`stopStreaming` test (#12 commit) covers the in-input stop button.
+- **Sprint 4.3 closes the entire `qa-2026-04-26` baseline-QA backlog.** After merge, only #39 (out-of-scope discovery from Sprint 4.2b — empty-msg-on-abort persistence) and any future QA-run umbrellas remain open. Bounty deadline 2026-05-12 = 14 days from session date.
+- **Phase D (GTM) becomes next priority** after Sprint 4.3 ships. RECTOR-driven (demo video recording, README screenshots, tweet thread, Superteam submission, judging rehearsal). This sprint's UI improvements (#14 tooltip + #15 clickable cards) directly improve Phase D demo discoverability.
+- **No infrastructure changes.** No VPS, env-var, or Cloudflare changes. Vercel + GitLab mirror auto-trigger on PR lifecycle as usual.

--- a/server/ratelimit.test.ts
+++ b/server/ratelimit.test.ts
@@ -56,16 +56,6 @@ describe('identify', () => {
     expect(identify(req)).toBe('203.0.113.1');
   });
 
-  it('returns "anonymous" when no IP headers are present outside production', () => {
-    const origEnv = process.env.NODE_ENV;
-    delete process.env.NODE_ENV;
-    try {
-      expect(identify(mockReq({}))).toBe('anonymous');
-    } finally {
-      if (origEnv !== undefined) process.env.NODE_ENV = origEnv;
-    }
-  });
-
   it('returns empty string when no IP headers are present in production (fail-closed)', () => {
     const origEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';
@@ -85,6 +75,17 @@ describe('identify', () => {
   it('trims whitespace from header values', () => {
     const req = mockReq({ 'x-forwarded-for': '  203.0.113.1  ,  10.0.0.2  ' });
     expect(identify(req)).toBe('203.0.113.1');
+  });
+
+  it('returns a dev-prefixed UUID-shaped token outside production when no IP headers are present', () => {
+    const origEnv = process.env.NODE_ENV;
+    delete process.env.NODE_ENV;
+    try {
+      const id = identify(mockReq({}));
+      expect(id).toMatch(/^dev-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    } finally {
+      if (origEnv !== undefined) process.env.NODE_ENV = origEnv;
+    }
   });
 });
 

--- a/server/ratelimit.ts
+++ b/server/ratelimit.ts
@@ -4,6 +4,8 @@ import { Redis } from '@upstash/redis';
 
 type Duration = `${number} ${'ms' | 's' | 'm' | 'h' | 'd'}`;
 
+const DEV_TOKEN: string = `dev-${typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : 'fallback-' + Date.now().toString(36)}`;
+
 export interface LimiterConfig {
   name: string;
   limit: number;
@@ -61,8 +63,11 @@ export function identify(req: IncomingMessage): string {
   if (ip) return ip;
   // Vercel always populates x-forwarded-for on incoming traffic. A missing IP
   // in production is anomalous — refuse to bucket every such caller under a
-  // shared 'anonymous' key that a single actor could then exhaust and DoS.
-  return process.env.NODE_ENV === 'production' ? '' : 'anonymous';
+  // shared key that a single actor could then exhaust and DoS. Outside
+  // production, return a per-process random token so a dev build accidentally
+  // pointed at the real Upstash doesn't share the 'anonymous' bucket with
+  // every other dev caller.
+  return process.env.NODE_ENV === 'production' ? '' : DEV_TOKEN;
 }
 
 export async function applyLimit(

--- a/server/rpc-guards.test.ts
+++ b/server/rpc-guards.test.ts
@@ -1,43 +1,74 @@
 import { describe, it, expect } from 'vitest';
 import {
-  deniedMethodIn,
+  disallowedMethodIn,
   oversizedParamsIn,
+  ALLOWED_METHODS,
   MAX_BATCH_SIZE,
   MAX_PARAMS_ARRAY_LENGTH,
 } from './rpc-guards';
 
-describe('deniedMethodIn', () => {
-  it('returns the method name when a single call uses a denied method', () => {
-    expect(deniedMethodIn({ jsonrpc: '2.0', id: 1, method: 'getProgramAccounts' })).toBe(
+describe('disallowedMethodIn', () => {
+  it('returns null for an allowlisted method', () => {
+    expect(disallowedMethodIn({ jsonrpc: '2.0', id: 1, method: 'getHealth' })).toBeNull();
+  });
+
+  it('returns the method name when an arbitrary (non-allowlisted) method is used', () => {
+    expect(disallowedMethodIn({ jsonrpc: '2.0', id: 1, method: 'getProgramAccounts' })).toBe(
       'getProgramAccounts',
     );
   });
 
-  it('returns null for allowed methods', () => {
-    expect(deniedMethodIn({ jsonrpc: '2.0', id: 1, method: 'getHealth' })).toBeNull();
+  it('returns the method name for newly-shipped Solana RPC methods (drift safety)', () => {
+    // Hypothetical future method — the allowlist explicitly opts in, so an
+    // unknown method 403s by default rather than silently relaying.
+    expect(disallowedMethodIn({ jsonrpc: '2.0', id: 1, method: 'getFutureBlockchainSomething' })).toBe(
+      'getFutureBlockchainSomething',
+    );
   });
 
-  it('scans batch arrays and flags the first denied method', () => {
+  it('scans batch arrays and flags the first disallowed method', () => {
     const batch = [
       { jsonrpc: '2.0', id: 1, method: 'getHealth' },
-      { jsonrpc: '2.0', id: 2, method: 'getBlock' },
+      { jsonrpc: '2.0', id: 2, method: 'getProgramAccounts' },
     ];
-    expect(deniedMethodIn(batch)).toBe('getBlock');
+    expect(disallowedMethodIn(batch)).toBe('getProgramAccounts');
   });
 
-  it('returns null for batches of allowed methods', () => {
+  it('returns null for batches of allowlisted methods', () => {
     const batch = [
       { jsonrpc: '2.0', id: 1, method: 'getHealth' },
       { jsonrpc: '2.0', id: 2, method: 'getBalance' },
     ];
-    expect(deniedMethodIn(batch)).toBeNull();
+    expect(disallowedMethodIn(batch)).toBeNull();
   });
 
   it('tolerates malformed payloads', () => {
-    expect(deniedMethodIn(null)).toBeNull();
-    expect(deniedMethodIn(undefined)).toBeNull();
-    expect(deniedMethodIn('not an object')).toBeNull();
-    expect(deniedMethodIn({ method: 42 })).toBeNull();
+    expect(disallowedMethodIn(null)).toBeNull();
+    expect(disallowedMethodIn(undefined)).toBeNull();
+    expect(disallowedMethodIn('not an object')).toBeNull();
+    expect(disallowedMethodIn({ method: 42 })).toBeNull();
+  });
+});
+
+describe('ALLOWED_METHODS membership', () => {
+  it('includes every method the app actually uses', () => {
+    // This list is the contract — if the app starts using a new RPC method,
+    // add it here AND to ALLOWED_METHODS in rpc-guards.ts.
+    const expected = [
+      'getHealth',
+      'getLatestBlockhash',
+      'simulateTransaction',
+      'sendTransaction',
+      'getSignatureStatuses',
+      'getBlockHeight',
+      'getMinimumBalanceForRentExemption',
+      'getBalance',
+      'getAccountInfo',
+      'getMultipleAccounts',
+    ];
+    for (const method of expected) {
+      expect(ALLOWED_METHODS.has(method)).toBe(true);
+    }
   });
 });
 

--- a/server/rpc-guards.ts
+++ b/server/rpc-guards.ts
@@ -1,30 +1,28 @@
 export const MAX_BATCH_SIZE = 20;
 export const MAX_PARAMS_ARRAY_LENGTH = 100;
 
-export const DENIED_METHODS = new Set([
-  'getProgramAccounts',
-  'getSignaturesForAddress',
-  'getConfirmedSignaturesForAddress2',
-  'getConfirmedBlock',
-  'getBlock',
-  'getBlocks',
-  'getBlocksWithLimit',
-  'getBlockProduction',
-  'getInflationReward',
-  'getRecentPerformanceSamples',
-  'getRecentPrioritizationFees',
-  'getLargestAccounts',
-  'getSupply',
-  'getVoteAccounts',
-  'getClusterNodes',
+export const ALLOWED_METHODS = new Set([
+  // Connectivity / health
+  'getHealth',
+  // Transaction lifecycle
+  'getLatestBlockhash',
+  'simulateTransaction',
+  'sendTransaction',
+  'getSignatureStatuses',
+  'getBlockHeight',
+  'getMinimumBalanceForRentExemption',
+  // Wallet / account reads
+  'getBalance',
+  'getAccountInfo',
+  'getMultipleAccounts',
 ]);
 
-export function deniedMethodIn(payload: unknown): string | null {
+export function disallowedMethodIn(payload: unknown): string | null {
   const calls = Array.isArray(payload) ? payload : [payload];
   for (const c of calls) {
     if (c && typeof c === 'object' && typeof (c as { method?: unknown }).method === 'string') {
       const method = (c as { method: string }).method;
-      if (DENIED_METHODS.has(method)) return method;
+      if (!ALLOWED_METHODS.has(method)) return method;
     }
   }
   return null;
@@ -32,11 +30,10 @@ export function deniedMethodIn(payload: unknown): string | null {
 
 // NOTE: This guard inspects only DIRECT array children of `params`. RPC methods
 // that wrap long arrays inside config objects (e.g.,
-// `params: [{ accounts: [...100 items...] }]`) would slip through. Today's
-// DENIED_METHODS set covers the high-cardinality methods (getProgramAccounts,
-// getSignaturesForAddress, etc.); if a new high-cardinality method ships with
-// nested array params, audit this function for recursive descent before
-// relying on it.
+// `params: [{ accounts: [...100 items...] }]`) would slip through. The current
+// ALLOWED_METHODS set covers methods whose direct-params shape is well-known;
+// if an allowlist addition has nested array params, audit this function for
+// recursive descent before relying on it.
 export function oversizedParamsIn(payload: unknown): string | null {
   if (Array.isArray(payload) && payload.length > MAX_BATCH_SIZE) {
     return `batch of ${payload.length} calls exceeds limit of ${MAX_BATCH_SIZE}`;

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -62,7 +62,7 @@ export default function ChatPanel({ conversation, isStreaming, onSend, onStop, o
           </div>
         </div>
       ) : (
-        <EmptyState />
+        <EmptyState onSend={handleSend} />
       )}
 
       {/* Input */}

--- a/src/components/EmptyState.test.tsx
+++ b/src/components/EmptyState.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@solana/wallet-adapter-react', () => ({
+  useWallet: () => ({ connected: false, connecting: false, wallets: [] }),
+}));
+
+vi.mock('@solana/wallet-adapter-react-ui', () => ({
+  useWalletModal: () => ({ setVisible: vi.fn() }),
+}));
+
+import EmptyState from './EmptyState';
+
+describe('EmptyState feature cards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all 4 feature card titles', () => {
+    render(<EmptyState onSend={vi.fn()} />);
+    expect(screen.getByText('Live Yields')).toBeInTheDocument();
+    expect(screen.getByText('Build & Sign')).toBeInTheDocument();
+    expect(screen.getByText('Portfolio')).toBeInTheDocument();
+    expect(screen.getByText('Health Sim')).toBeInTheDocument();
+  });
+
+  it('fires the Live Yields query on click', () => {
+    const onSend = vi.fn();
+    render(<EmptyState onSend={onSend} />);
+    fireEvent.click(screen.getByText('Live Yields').closest('button')!);
+    expect(onSend).toHaveBeenCalledWith('What are the best Kamino yields right now?');
+  });
+
+  it('fires the Build & Sign query on click', () => {
+    const onSend = vi.fn();
+    render(<EmptyState onSend={onSend} />);
+    fireEvent.click(screen.getByText('Build & Sign').closest('button')!);
+    expect(onSend).toHaveBeenCalledWith('Show me a 5 USDC deposit example');
+  });
+
+  it('fires the Portfolio query on click', () => {
+    const onSend = vi.fn();
+    render(<EmptyState onSend={onSend} />);
+    fireEvent.click(screen.getByText('Portfolio').closest('button')!);
+    expect(onSend).toHaveBeenCalledWith('Show me my Kamino portfolio');
+  });
+
+  it('fires the Health Sim query on click', () => {
+    const onSend = vi.fn();
+    render(<EmptyState onSend={onSend} />);
+    fireEvent.click(screen.getByText('Health Sim').closest('button')!);
+    expect(onSend).toHaveBeenCalledWith('Will my borrow position liquidate at SOL $50?');
+  });
+});

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -18,7 +18,11 @@ function SolflareLogo({ className }: { className?: string }) {
   );
 }
 
-export default function EmptyState() {
+interface Props {
+  onSend: (msg: string) => void;
+}
+
+export default function EmptyState({ onSend }: Props) {
   const { connected, connecting, wallets } = useWallet();
   const { setVisible } = useWalletModal();
 
@@ -50,20 +54,42 @@ export default function EmptyState() {
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-left mb-6">
           {(
             [
-              { Icon: TrendingUp, title: 'Live Yields', desc: 'Find best APYs on Kamino' },
-              { Icon: ArrowLeftRight, title: 'Build & Sign', desc: 'Deposit, borrow, withdraw, repay' },
-              { Icon: Wallet, title: 'Portfolio', desc: 'Your Kamino positions + APY' },
-              { Icon: ShieldCheck, title: 'Health Sim', desc: 'Liquidation-risk checks' },
-            ] satisfies Array<{ Icon: LucideIcon; title: string; desc: string }>
-          ).map(({ Icon, title, desc }) => (
-            <div
+              {
+                Icon: TrendingUp,
+                title: 'Live Yields',
+                desc: 'Find best APYs on Kamino',
+                query: 'What are the best Kamino yields right now?',
+              },
+              {
+                Icon: ArrowLeftRight,
+                title: 'Build & Sign',
+                desc: 'Deposit, borrow, withdraw, repay',
+                query: 'Show me a 5 USDC deposit example',
+              },
+              {
+                Icon: Wallet,
+                title: 'Portfolio',
+                desc: 'Your Kamino positions + APY',
+                query: 'Show me my Kamino portfolio',
+              },
+              {
+                Icon: ShieldCheck,
+                title: 'Health Sim',
+                desc: 'Liquidation-risk checks',
+                query: 'Will my borrow position liquidate at SOL $50?',
+              },
+            ] satisfies Array<{ Icon: LucideIcon; title: string; desc: string; query: string }>
+          ).map(({ Icon, title, desc, query }) => (
+            <button
               key={title}
-              className="p-3 rounded-xl border border-kami-border bg-kami-surface/50 hover:bg-kami-surface transition-colors"
+              type="button"
+              onClick={() => onSend(query)}
+              className="text-left p-3 rounded-xl border border-kami-border bg-kami-surface/50 hover:bg-kami-surface transition-colors cursor-pointer"
             >
               <Icon className="w-5 h-5 text-kami-accent mb-2" aria-hidden="true" />
               <div className="text-sm font-medium text-white">{title}</div>
               <div className="text-xs text-kami-muted">{desc}</div>
-            </div>
+            </button>
           ))}
         </div>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -171,7 +171,7 @@ export default function Sidebar({
                   className="flex-1 min-w-0 bg-transparent border border-kami-border rounded px-1 py-0.5 text-sm text-white focus:outline-none focus:border-kami-accent"
                 />
               ) : (
-                <span className="flex-1 truncate">{conv.title}</span>
+                <span className="flex-1 truncate" title={conv.title}>{conv.title}</span>
               )}
               {editingId !== conv.id && (
                 <>

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -291,3 +291,125 @@ describe('useChat renameConversation', () => {
     expect(result.current.conversations[0].title).toBe('keep this');
   });
 });
+
+describe('useChat sendMessage streaming', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function streamResponse(chunks: string[]): Response {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+  }
+
+  it('accumulates text-delta chunks into the assistant message content', async () => {
+    global.fetch = vi.fn(async () =>
+      streamResponse([
+        'data: {"text":"Hello"}\n',
+        'data: {"text":", "}\n',
+        'data: {"text":"world."}\n',
+        'data: [DONE]\n',
+      ])
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      await result.current.sendMessage('hi');
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    const assistantMsg = result.current.activeConversation.messages.find((m) => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.content).toBe('Hello, world.');
+  });
+
+  it('threads toolCall + toolResult chunks into messages[last].toolCalls', async () => {
+    global.fetch = vi.fn(async () =>
+      streamResponse([
+        'data: {"toolCall":{"id":"tc-1","name":"getPortfolio"}}\n',
+        'data: {"toolResult":{"id":"tc-1","name":"getPortfolio","output":{"ok":true,"data":{"positions":[]}}}}\n',
+        'data: {"text":"You have no positions."}\n',
+        'data: [DONE]\n',
+      ])
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      await result.current.sendMessage('show me my portfolio');
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    const assistantMsg = result.current.activeConversation.messages.find((m) => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.toolCalls).toHaveLength(1);
+    expect(assistantMsg!.toolCalls![0].id).toBe('tc-1');
+    expect(assistantMsg!.toolCalls![0].name).toBe('getPortfolio');
+    expect(assistantMsg!.toolCalls![0].status).toBe('done');
+    expect(assistantMsg!.content).toBe('You have no positions.');
+  });
+
+  it('marks toolCalls as error when a toolError chunk arrives', async () => {
+    global.fetch = vi.fn(async () =>
+      streamResponse([
+        'data: {"toolCall":{"id":"tc-1","name":"buildDeposit"}}\n',
+        'data: {"toolError":{"id":"tc-1","name":"buildDeposit","error":"insufficient balance"}}\n',
+        'data: [DONE]\n',
+      ])
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      await result.current.sendMessage('deposit 5 USDC');
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    const assistantMsg = result.current.activeConversation.messages.find((m) => m.role === 'assistant');
+    expect(assistantMsg!.toolCalls).toHaveLength(1);
+    expect(assistantMsg!.toolCalls![0].status).toBe('error');
+    expect(assistantMsg!.toolCalls![0].error).toBe('insufficient balance');
+  });
+
+  it('aborts the in-flight stream when stopStreaming is called', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    global.fetch = vi.fn((_url: unknown, init: unknown) => {
+      capturedSignal = (init as RequestInit | undefined)?.signal ?? undefined;
+      return new Promise(() => {});
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      result.current.sendMessage('hello');
+    });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(capturedSignal?.aborted).toBe(false);
+
+    act(() => {
+      result.current.stopStreaming();
+    });
+
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(result.current.isStreaming).toBe(false);
+  });
+});

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -179,7 +179,7 @@ export function useChat() {
           content: m.content,
         }));
 
-        const response = await fetch('api/chat', {
+        const response = await fetch('/api/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({


### PR DESCRIPTION
## Summary

Sprint 4.3 — closes the remaining 6 P1 items in the `qa-2026-04-26` backlog. After this PR merges, the entire 2026-04-26 baseline-QA backlog is cleared and umbrella issue #3 closes (manually — GitHub doesn't auto-close umbrellas).

Six sub-changes, one commit per logical change:

- **#9 D-5 (commit 1):** `fetch('api/chat')` → `fetch('/api/chat')`. Single-character fix; relative form would break under sub-path routing.
- **#10 D-9 (commit 2):** Cache `'dev-' + crypto.randomUUID()` at module load; return it from `identify()` outside production. Production fail-closed behavior unchanged. Stops a dev build accidentally pointed at real Upstash from sharing the `'anonymous'` bucket with every other dev caller.
- **#11 D-10 (commit 3):** Replace `DENIED_METHODS` denylist with `ALLOWED_METHODS` allowlist of the 10 RPC methods Kami actually calls. Rename `deniedMethodIn` → `disallowedMethodIn`. Adds drift-safety + membership tests.
- **#12 D-11 (commit 4):** +4 streaming/sequencing/abort tests in `useChat.test.ts`. Targets the actual coverage gap — D-3 + D-4 regression cases were already covered in earlier sprints; this commit codifies text-delta accumulation, tool-call/result/error chunk wiring, and the in-input `stopStreaming` abort path.
- **#14 U-5 (commit 5):** Add `title={conv.title}` to the static-title `<span>` in Sidebar. Native HTML tooltip on hover. Accessible, zero JS.
- **#15 U-7 (commit 6):** Convert the 4 empty-state cards from `<div>` to `<button type="button">` with `onClick` firing each card's representative query through a new `onSend` prop. `cursor-pointer` makes the affordance explicit. ChatPanel passes its existing `handleSend` (wallet-aware).

## Test plan

- 11 new tests across 4 test files (`server/ratelimit.test.ts` net 0 (1 deleted obsolete + 1 added regex), `server/rpc-guards.test.ts` +2, `src/hooks/useChat.test.ts` +4, `src/components/EmptyState.test.tsx` NEW +5)
- `pnpm test:run`: 175 → 186 across 20 → 21 files
- TDD red → green on tasks 2, 6
- Cluster reviewer (opus): SHIP IT, 0 Critical / 0 Important / 13 Minor deferred. Mutation-tested 3 invariants (allowlist non-membership returns method name, EmptyState card click fires exact query, dev-token shape regex) — all caught their regressions.
- [ ] Manual smoke post-deploy: submit chat query → confirm 200 from `/api/chat` (#9)
- [ ] Manual smoke post-deploy: `X-RateLimit-*` headers show `dev-` identifier in dev / real IP in prod (#10)
- [ ] Manual smoke post-deploy: wallet-sign a deposit → no `/api/rpc` 403s (#11)
- [ ] Manual smoke post-deploy: hover sidebar row → native tooltip with full title (#14)
- [ ] Manual smoke post-deploy: click each empty-state card → matching query sent (#15)

## Closes

Closes #9
Closes #10
Closes #11
Closes #12
Closes #14
Closes #15

**Note for merger:** after merge, manually close umbrella issue #3 — all 27 child issues from the 2026-04-26 baseline QA run will be closed.