### PR TITLE
docs(demo-script): sync Shot 2 + Shot 3 with Sprint 4.3 UX

### DIFF
--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -18,15 +18,15 @@ VO: *"DeFi dashboards assume you already know what you're doing. Kami flips that
 
 ## Shot 2 — Connect (0:25–0:40)
 
-UI: `kami.rectorspace.com` landing — "Welcome to Kami" tiles visible, 4 suggestion chips along the bottom, "Connect with Solflare" orange CTA center.
+UI: `kami.rectorspace.com` landing — gradient **K** logo + "Welcome to Kami" heading, four feature cards arranged in a 2×2 grid (**Live Yields** / **Build & Sign** / **Portfolio** / **Health Sim**), and the orange **Connect with Solflare** CTA below the grid.
 
-Action: click **Connect with Solflare** → Solflare extension popup → Approve. Wallet badge `HciZ..25En` appears top-right, tiles stay, CTA disappears.
+Action: click **Connect with Solflare** → Solflare extension popup → Approve. Wallet badge `HciZ..25En` appears top-right, the cards stay, the Connect CTA disappears.
 
 VO: *"Connect a Solana wallet — Solflare recommended, or anything Wallet-Standard compatible. No new accounts, no sign-in forms. The wallet is the auth."*
 
 ## Shot 3 — Find yield (0:40–0:55)
 
-Action: click the chip **"What's the best USDC supply APY on Kamino right now?"** → it auto-submits.
+Action: click the **Live Yields** card (top-left of the 2×2 grid) → it fires *"What are the best Kamino yields right now?"* and auto-submits.
 
 UI: tool-call badges render: `Calling findYield` (green). Assistant streams a markdown **table** with columns [Market · Reserve · Supply APY · Borrow APY · Utilization]. Top row highlighted.
 


### PR DESCRIPTION
## Summary

Pre-flight sync of the bounty demo script against current shipped UX. The script was drafted on Day 6 when the empty-state suggestions were static "chips along the bottom"; Sprint 4.3 (PR #41 / U-7) converted them into clickable cards arranged in a 2×2 grid above the Connect CTA.

## Drift fixes

- **Shot 2 layout description** — replace the inaccurate "*Welcome to Kami tiles + 4 suggestion chips along the bottom + Connect CTA center*" with the actual layout: gradient K logo, "Welcome to Kami" heading, four named feature cards (**Live Yields** / **Build & Sign** / **Portfolio** / **Health Sim**) in a 2×2 grid, orange **Connect with Solflare** CTA below the grid.
- **Shot 3 action** — replace the made-up query *"What's the best USDC supply APY on Kamino right now?"* with the actual query the **Live Yields** card fires — *"What are the best Kamino yields right now?"* — and rename "click the chip" to "click the **Live Yields** card (top-left of the 2×2 grid)". This matches `EmptyState.tsx:61` exactly.

## Re-checked, no drift found

- **Tweet thread** (`docs/tweet-thread.md`) — all five tweets, character counts table, handle-verify list, posting checklist, and alternative framings re-read end-to-end. All still accurate.
- **Demo Script** Shots 1, 4–8, cold open, closer, production checklist, archive signatures, backup deliverables — re-read; no further drift.
- **Architecture diagram** (`assets/architecture.svg`) — referenced by both README and demo-script cold open. Still current.
- **Tool-call badge format** (`Calling findYield` etc.) — Sprint 3.1 added dedup with `×N` suffix for repeated calls; single-call format is unchanged. Script's single-call references are fine.

## Test plan

- [ ] Read the updated `docs/demo-script.md` Shot 2 + Shot 3 against `kami.rectorspace.com` in a private window
- [ ] Hover the **Live Yields** card and confirm `EmptyState.tsx:61` query string matches: *"What are the best Kamino yields right now?"*
- [ ] Click the **Live Yields** card and confirm it fires the query and the `findYield` tool-call badge renders
- [ ] (Recording-time) Confirm wallet badge format `HciZ..25En` matches your actual demo wallet shorthand