### PR TITLE
feat(landing): bento amber pre-connect landing redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage/
 
 # QA reports (gitignored — use --commit to publish)
 .qa/
+.superpowers/

--- a/docs/superpowers/plans/2026-04-28-kami-landing-bento-amber-implementation.md
+++ b/docs/superpowers/plans/2026-04-28-kami-landing-bento-amber-implementation.md
@@ -1,0 +1,1729 @@
+# Kami Landing — Bento + Amber Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current minimal `EmptyState.tsx` (gradient K logo + 4 feature cards + CTA) with a bento-grid pre-connect landing using an amber-on-sepia palette. Hero cell + 2 stat cells + 4 tool cells + 1 pipeline cell + 1 sponsor strip = 9 cells across a 12-column grid.
+
+**Architecture:** Decompose `EmptyState.tsx` into 8 focused sub-components under `src/components/landing/`. Each cell is a presentation component fed by hardcoded constants in `src/lib/landing-content.ts`. The wallet-connect wiring stays in `EmptyState.tsx`; child cells are pure (props in, JSX out). Animations + colors are Tailwind-theme additions, not inline styles. The chat shell (ChatPanel/Sidebar/etc.) is unchanged — restyling it is a follow-up spec out of scope here.
+
+**Tech Stack:** React 18 + TypeScript + Vite + Tailwind 3.4 + Lucide React (already installed). Tests via Vitest + @testing-library/react (happy-dom env). Google Fonts (Unbounded — added; Inter and JetBrains Mono — already loaded).
+
+---
+
+## Spec reference
+
+`docs/superpowers/specs/2026-04-28-kami-landing-bento-amber-design.md` (committed at `de626e3`). Read it before starting.
+
+## Open questions resolved during planning
+
+These were spec §8 open questions — locked here so implementation has no ambiguity:
+
+1. **CTA copy**: `Connect with Solflare` (matches current `EmptyState.tsx` and bounty-Solflare alignment).
+2. **Cell border-radius**: `rounded-3xl` (1.5rem) default for all cells; `rounded-[2rem]` (2rem) for the hero cell.
+3. **Latest tx signature**: Day-6 deposit `5XKeETjGfmj9jEWUNCKcf8u49bY4hEzX2a7JcB4nPxQCBbmZ7ipoNrgTXQMJWXHvKw7Bsera9xxYygLVxLUpUvZE`. Solscan URL: `https://solscan.io/tx/<full-sig>`.
+4. **Tool cell hint format**: arrow form — `→ KaminoMarket.reserves`, `→ KaminoMarket.getObligationByAddress`, `→ Obligation.simulateBorrowAndWithdrawAction`, `→ KaminoAction.build*Txns`.
+5. **Sponsor links**: text-only for v1 (no anchors). Eitherway · Kamino · Solflare · Helius · Vercel.
+
+## Open questions surfaced during planning (RECTOR confirms before execution)
+
+1. **Tool cells are non-clickable per spec §5.4.** Current `EmptyState.tsx` cards fire queries via `onSend` (Sprint 4.3 / U-7 wired this Day 16). Bento drops the click-to-fire behavior — visitors who want to type queries do so via `ChatInput` post-connect. Confirm we accept the regression of "click a card to sample a query."
+2. **Bento renders when `conversation.messages.length === 0`** (existing condition), not `connected === false` as spec §6.1 says. The existing condition includes both pre-connect AND post-connect-empty-conversation. Keeping this is safer — flipping to `!connected` would make returning users (post-connect, fresh conversation) skip the bento and see a different empty state. Confirm.
+
+## Token naming + theme strategy
+
+Spec §3.1 names tokens `kami-bg`, `kami-cell-base`, `kami-text`, etc. Some collide with existing Tailwind tokens (`kami.bg = #0a0a0f`, `kami.text = #e2e8f0`). To avoid breaking the chat shell during this transition:
+
+- **Extend** the `kami` namespace with NEW tokens that don't collide: `kami.sepiaBg`, `kami.cellBase`, `kami.cellElevated`, `kami.cellBorder`, `kami.cream`, `kami.creamMuted`, `kami.amber`, `kami.amberGlow`, `kami.amberHaze`.
+- **Preserve** all existing `kami.*` tokens unchanged. Body bg stays `#0a0a0f`; only the bento outer wrapper applies `bg-kami-sepiaBg`.
+- **Defer** removing the `kami.accent` purple to the chat-shell restyle follow-up (spec §6.2).
+
+## File structure (new + modified)
+
+**Created:**
+- `src/lib/landing-content.ts` — hardcoded constants (stats, tx, sponsors, tools, pipeline)
+- `src/lib/landing-content.test.ts` — shape tests
+- `src/components/landing/KamiCursor.tsx` — `▌` blink primitive
+- `src/components/landing/KamiCursor.test.tsx`
+- `src/components/landing/BentoCell.tsx` — shared cell wrapper
+- `src/components/landing/BentoCell.test.tsx`
+- `src/components/landing/HeroCell.tsx` — hero w/ CTA
+- `src/components/landing/HeroCell.test.tsx`
+- `src/components/landing/SysMetricsCell.tsx` — stats list
+- `src/components/landing/SysMetricsCell.test.tsx`
+- `src/components/landing/LatestTxCell.tsx` — proof-of-life card
+- `src/components/landing/LatestTxCell.test.tsx`
+- `src/components/landing/ToolCell.tsx` — single tool tile
+- `src/components/landing/ToolCell.test.tsx`
+- `src/components/landing/PipelineCell.tsx` — 3-step strip
+- `src/components/landing/PipelineCell.test.tsx`
+- `src/components/landing/SponsorStrip.tsx` — wordmarks
+- `src/components/landing/SponsorStrip.test.tsx`
+
+**Modified:**
+- `tailwind.config.js` — colors, fontFamily, transitionTimingFunction, keyframes, animation
+- `index.html` — Unbounded Google Fonts
+- `src/components/EmptyState.tsx` — full rewrite as bento grid composer
+- `src/components/EmptyState.test.tsx` — refreshed integration tests
+- `src/components/ChatPanel.tsx` — drop `onSend` prop on `<EmptyState>` (no longer needed)
+
+**Test count delta:** 186 → 222 (`+36` net across 9 new test files + 1 refreshed file: +5 landing-content, +3 KamiCursor, +4 BentoCell, +6 HeroCell, +4 SysMetricsCell, +4 LatestTxCell, +3 ToolCell, +3 PipelineCell, +2 SponsorStrip, –5 +7 EmptyState refresh).
+
+---
+
+### Task 1: Tailwind theme + Unbounded font + landing-content constants
+
+**Files:**
+- Modify: `tailwind.config.js`
+- Modify: `index.html`
+- Create: `src/lib/landing-content.ts`
+- Test: `src/lib/landing-content.test.ts`
+
+- [ ] **Step 1: Write the failing test for landing-content shape**
+
+Create `src/lib/landing-content.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  LANDING_STATS,
+  LATEST_TX,
+  SPONSORS,
+  TOOL_CELLS,
+  PIPELINE_STEPS,
+} from './landing-content';
+
+describe('landing-content', () => {
+  it('LANDING_STATS has 4 entries with key/value/highlight shape', () => {
+    expect(LANDING_STATS).toHaveLength(4);
+    LANDING_STATS.forEach((s) => {
+      expect(typeof s.key).toBe('string');
+      expect(typeof s.value).toBe('string');
+      expect(typeof s.highlight).toBe('boolean');
+    });
+    expect(LANDING_STATS[0].key).toBe('sys.tools_loaded');
+    expect(LANDING_STATS[0].highlight).toBe(true);
+  });
+
+  it('LATEST_TX has the Day-6 mainnet signature + Solscan URL', () => {
+    expect(LATEST_TX.signature).toMatch(/^[1-9A-HJ-NP-Za-km-z]{86,90}$/);
+    expect(LATEST_TX.solscanUrl).toContain(LATEST_TX.signature);
+    expect(LATEST_TX.solscanUrl.startsWith('https://solscan.io/tx/')).toBe(true);
+    expect(LATEST_TX.action).toBe('5 USDC supplied to Kamino');
+  });
+
+  it('SPONSORS includes the 5 bounty-acknowledged sponsors in order', () => {
+    expect(SPONSORS).toEqual(['Eitherway', 'Kamino', 'Solflare', 'Helius', 'Vercel']);
+  });
+
+  it('TOOL_CELLS has 4 entries with name/description/hint/iconKey shape', () => {
+    expect(TOOL_CELLS).toHaveLength(4);
+    const names = TOOL_CELLS.map((t) => t.name);
+    expect(names).toEqual([
+      'tool/findYield',
+      'tool/getPortfolio',
+      'tool/simulateHealth',
+      'tool/buildSign',
+    ]);
+    TOOL_CELLS.forEach((t) => {
+      expect(typeof t.description).toBe('string');
+      expect(t.hint.startsWith('→ ')).toBe(true);
+      expect(typeof t.iconKey).toBe('string');
+    });
+  });
+
+  it('PIPELINE_STEPS has 3 entries with index/label/iconKey shape', () => {
+    expect(PIPELINE_STEPS).toHaveLength(3);
+    const labels = PIPELINE_STEPS.map((p) => p.label);
+    expect(labels).toEqual(['INTENT', 'SIGNATURE', 'EXECUTION']);
+    PIPELINE_STEPS.forEach((p, i) => {
+      expect(p.index).toBe(`${i + 1}/3`);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test:run src/lib/landing-content.test.ts
+```
+
+Expected: FAIL — `Cannot find module './landing-content'`.
+
+- [ ] **Step 3: Implement landing-content.ts**
+
+Create `src/lib/landing-content.ts`:
+
+```ts
+// Hardcoded data for the bento landing. Centralized so future
+// updates (test count drifts, new sponsors) touch one place.
+
+export interface LandingStat {
+  key: string;
+  value: string;
+  highlight: boolean;
+}
+
+export const LANDING_STATS: ReadonlyArray<LandingStat> = [
+  { key: 'sys.tools_loaded', value: '7 active', highlight: true },
+  { key: 'ci.tests_passing', value: '186 suite', highlight: false },
+  { key: 'net.roundtrips', value: '3 mainnet', highlight: false },
+  { key: 'sys.genesis', value: '2026-04-19', highlight: false },
+];
+
+export interface LatestTx {
+  signature: string;
+  shortSignature: string;
+  solscanUrl: string;
+  action: string;
+}
+
+const TX_SIG = '5XKeETjGfmj9jEWUNCKcf8u49bY4hEzX2a7JcB4nPxQCBbmZ7ipoNrgTXQMJWXHvKw7Bsera9xxYygLVxLUpUvZE';
+
+export const LATEST_TX: LatestTx = {
+  signature: TX_SIG,
+  shortSignature: `${TX_SIG.slice(0, 10)}…${TX_SIG.slice(-5)}`,
+  solscanUrl: `https://solscan.io/tx/${TX_SIG}`,
+  action: '5 USDC supplied to Kamino',
+};
+
+export const SPONSORS: ReadonlyArray<string> = [
+  'Eitherway',
+  'Kamino',
+  'Solflare',
+  'Helius',
+  'Vercel',
+];
+
+export type ToolIconKey =
+  | 'findYield'
+  | 'getPortfolio'
+  | 'simulateHealth'
+  | 'buildSign';
+
+export interface ToolCellData {
+  name: string;
+  description: string;
+  hint: string;
+  iconKey: ToolIconKey;
+}
+
+export const TOOL_CELLS: ReadonlyArray<ToolCellData> = [
+  {
+    name: 'tool/findYield',
+    description: 'Scans Kamino reserves for highest supply / borrow APY.',
+    hint: '→ KaminoMarket.reserves',
+    iconKey: 'findYield',
+  },
+  {
+    name: 'tool/getPortfolio',
+    description: "Fetches connected wallet's positions, debt, health factor.",
+    hint: '→ KaminoMarket.getObligationByAddress',
+    iconKey: 'getPortfolio',
+  },
+  {
+    name: 'tool/simulateHealth',
+    description: 'Projects post-action health factor before signing.',
+    hint: '→ Obligation.simulateBorrowAndWithdrawAction',
+    iconKey: 'simulateHealth',
+  },
+  {
+    name: 'tool/buildSign',
+    description: 'Builds + signs deposit / borrow / withdraw / repay v0 transactions.',
+    hint: '→ KaminoAction.build*Txns',
+    iconKey: 'buildSign',
+  },
+];
+
+export type PipelineIconKey = 'intent' | 'signature' | 'execution';
+
+export interface PipelineStep {
+  index: string;
+  label: string;
+  iconKey: PipelineIconKey;
+}
+
+export const PIPELINE_STEPS: ReadonlyArray<PipelineStep> = [
+  { index: '1/3', label: 'INTENT', iconKey: 'intent' },
+  { index: '2/3', label: 'SIGNATURE', iconKey: 'signature' },
+  { index: '3/3', label: 'EXECUTION', iconKey: 'execution' },
+];
+```
+
+- [ ] **Step 4: Run landing-content test**
+
+```bash
+pnpm test:run src/lib/landing-content.test.ts
+```
+
+Expected: PASS — 5 tests.
+
+- [ ] **Step 5: Update tailwind.config.js with new tokens**
+
+Replace `tailwind.config.js`:
+
+```js
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        kami: {
+          bg: '#0a0a0f',
+          surface: '#12121a',
+          border: '#1e1e2e',
+          accent: '#7c3aed',
+          accentHover: '#6d28d9',
+          text: '#e2e8f0',
+          muted: '#64748b',
+          user: '#1e1b4b',
+          assistant: '#171720',
+          success: '#10b981',
+          warning: '#f59e0b',
+          danger: '#ef4444',
+
+          // Bento landing palette (Sprint 5 / Day 18). The chat shell
+          // still uses kami.bg/surface/accent above; restyling that is
+          // a follow-up spec.
+          sepiaBg: '#1a1410',
+          cellBase: '#221a14',
+          cellElevated: '#2a2117',
+          cellBorder: 'rgba(245, 230, 211, 0.12)',
+          cream: '#F5E6D3',
+          creamMuted: 'rgba(245, 230, 211, 0.6)',
+          amber: '#FFA500',
+          amberGlow: 'rgba(255, 165, 0, 0.15)',
+          amberHaze: 'rgba(255, 165, 0, 0.05)',
+        },
+      },
+      fontFamily: {
+        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+        mono: ['JetBrains Mono', 'Fira Code', 'monospace'],
+        display: ['Unbounded', 'sans-serif'],
+      },
+      transitionTimingFunction: {
+        spring: 'cubic-bezier(0.175, 0.885, 0.32, 1.275)',
+        smooth: 'cubic-bezier(0.4, 0, 0.2, 1)',
+      },
+      keyframes: {
+        'cascade-up': {
+          '0%': { opacity: '0', transform: 'translateY(20px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        blink: {
+          '0%, 50%': { opacity: '1' },
+          '50.01%, 100%': { opacity: '0' },
+        },
+        'pulse-dot': {
+          '0%': { boxShadow: '0 0 0 0 rgba(255, 165, 0, 0.4)' },
+          '100%': { boxShadow: '0 0 0 8px rgba(255, 165, 0, 0)' },
+        },
+      },
+      animation: {
+        'cascade-up': 'cascade-up 800ms cubic-bezier(0.175, 0.885, 0.32, 1.275) backwards',
+        blink: 'blink 1s step-end infinite',
+        'pulse-dot': 'pulse-dot 2s ease-out infinite',
+      },
+    },
+  },
+  plugins: [],
+}
+```
+
+- [ ] **Step 6: Add Unbounded to index.html**
+
+Replace the `<link href="https://fonts.googleapis.com/css2?...">` line in `index.html` with one that adds Unbounded weights 700/800. The existing line is at line 11.
+
+Old line:
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+```
+
+New line:
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Unbounded:wght@700;800&display=swap" rel="stylesheet" />
+```
+
+(Also bumps JetBrains Mono to include weight 700, used for stat values + uppercase mono labels.)
+
+- [ ] **Step 7: Verify build passes**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm test:run
+```
+
+Expected: client typecheck silent. Server typecheck silent. All tests PASS (186 + 5 new = 191).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tailwind.config.js index.html src/lib/landing-content.ts src/lib/landing-content.test.ts
+git commit -m "$(cat <<'EOF'
+feat(landing): add bento amber theme tokens + Unbounded font + landing-content constants
+
+Sprint 5 Day 18, Task 1 of 7. Extends the kami Tailwind namespace with
+9 new tokens (sepiaBg, cellBase, cellElevated, cellBorder, cream,
+creamMuted, amber, amberGlow, amberHaze) for the bento landing.
+Existing kami.bg / surface / accent (purple) preserved during transition.
+
+Adds Unbounded display font (700/800) + bumps JetBrains Mono to weight
+700. Adds spring + smooth timing functions and cascade-up / blink /
+pulse-dot keyframes + animations.
+
+src/lib/landing-content.ts centralizes hardcoded landing data: 4
+sys.metrics rows, the Day-6 mainnet tx, 5 sponsors, 4 tool cells, 3
+pipeline steps. Shape tested by 5 new vitest cases.
+EOF
+)"
+```
+
+---
+
+### Task 2: KamiCursor + BentoCell primitives
+
+**Files:**
+- Create: `src/components/landing/KamiCursor.tsx`
+- Create: `src/components/landing/KamiCursor.test.tsx`
+- Create: `src/components/landing/BentoCell.tsx`
+- Create: `src/components/landing/BentoCell.test.tsx`
+
+- [ ] **Step 1: Write the failing KamiCursor test**
+
+Create `src/components/landing/KamiCursor.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import KamiCursor from './KamiCursor';
+
+describe('KamiCursor', () => {
+  it('renders the ▌ glyph', () => {
+    render(<KamiCursor />);
+    expect(screen.getByText('▌')).toBeInTheDocument();
+  });
+
+  it('applies the blink animation class', () => {
+    render(<KamiCursor />);
+    expect(screen.getByText('▌')).toHaveClass('animate-blink');
+  });
+
+  it('uses amber color', () => {
+    render(<KamiCursor />);
+    expect(screen.getByText('▌')).toHaveClass('text-kami-amber');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test:run src/components/landing/KamiCursor.test.tsx
+```
+
+Expected: FAIL — `Cannot find module './KamiCursor'`.
+
+- [ ] **Step 3: Implement KamiCursor**
+
+Create `src/components/landing/KamiCursor.tsx`:
+
+```tsx
+export default function KamiCursor() {
+  return (
+    <span className="text-kami-amber animate-blink" aria-hidden="true">
+      ▌
+    </span>
+  );
+}
+```
+
+- [ ] **Step 4: Run KamiCursor test**
+
+```bash
+pnpm test:run src/components/landing/KamiCursor.test.tsx
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Write the failing BentoCell test**
+
+Create `src/components/landing/BentoCell.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import BentoCell from './BentoCell';
+
+describe('BentoCell', () => {
+  it('renders children', () => {
+    render(
+      <BentoCell delay={1}>
+        <span>inner content</span>
+      </BentoCell>,
+    );
+    expect(screen.getByText('inner content')).toBeInTheDocument();
+  });
+
+  it('applies the className prop alongside cell base classes', () => {
+    const { container } = render(
+      <BentoCell delay={1} className="col-span-8 row-span-2">
+        x
+      </BentoCell>,
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).toContain('col-span-8');
+    expect(root.className).toContain('row-span-2');
+    expect(root.className).toContain('animate-cascade-up');
+  });
+
+  it('sets animationDelay from the delay prop (delay × 100ms)', () => {
+    const { container } = render(<BentoCell delay={3}>x</BentoCell>);
+    const root = container.firstChild as HTMLElement;
+    expect(root.style.animationDelay).toBe('300ms');
+  });
+
+  it('renders as <div> by default and accepts a different element via the `as` prop', () => {
+    const { container, rerender } = render(<BentoCell delay={1}>x</BentoCell>);
+    expect((container.firstChild as HTMLElement).tagName).toBe('DIV');
+
+    rerender(
+      <BentoCell delay={1} as="section">
+        x
+      </BentoCell>,
+    );
+    expect((container.firstChild as HTMLElement).tagName).toBe('SECTION');
+  });
+});
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+```bash
+pnpm test:run src/components/landing/BentoCell.test.tsx
+```
+
+Expected: FAIL — `Cannot find module './BentoCell'`.
+
+- [ ] **Step 7: Implement BentoCell**
+
+Create `src/components/landing/BentoCell.tsx`:
+
+```tsx
+import React from 'react';
+
+interface Props {
+  delay: number;
+  className?: string;
+  children: React.ReactNode;
+  as?: 'div' | 'section' | 'article';
+}
+
+export default function BentoCell({
+  delay,
+  className = '',
+  children,
+  as: Component = 'div',
+}: Props) {
+  return (
+    <Component
+      style={{ animationDelay: `${delay * 100}ms` }}
+      className={[
+        'relative overflow-hidden rounded-3xl',
+        'bg-kami-cellBase border border-kami-cellBorder',
+        'p-6 lg:p-8',
+        'transition-all duration-500 ease-smooth',
+        'hover:-translate-y-[2px] hover:border-kami-amber/40',
+        'hover:shadow-[0_10px_40px_-20px_rgba(255,165,0,0.15)]',
+        'animate-cascade-up',
+        className,
+      ].join(' ')}
+    >
+      {children}
+    </Component>
+  );
+}
+```
+
+- [ ] **Step 8: Run BentoCell test**
+
+```bash
+pnpm test:run src/components/landing/BentoCell.test.tsx
+```
+
+Expected: PASS — 4 tests.
+
+- [ ] **Step 9: Run full test suite + typechecks**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm test:run
+```
+
+Expected: client typecheck silent. All tests PASS (191 + 7 new = 198).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/components/landing/KamiCursor.tsx src/components/landing/KamiCursor.test.tsx src/components/landing/BentoCell.tsx src/components/landing/BentoCell.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(landing): add KamiCursor + BentoCell primitives
+
+Sprint 5 Day 18, Task 2 of 7. Two reusable primitives for the bento
+landing:
+
+- KamiCursor — amber ▌ with the blink keyframe (1s step-end infinite).
+  Anchors to the end of headlines (`Done▌`).
+- BentoCell — shared wrapper for every cell. Owns rounded-3xl border,
+  cell base bg, hover lift + amber glow, and the cascade-up entrance
+  animation. animationDelay is driven by a `delay` prop (delay × 100ms)
+  so the parent can stagger cells (1, 2, 3, …) without authoring
+  per-cell delay classes.
+
+7 new vitest cases.
+EOF
+)"
+```
+
+---
+
+### Task 3: HeroCell with CTA wiring
+
+**Files:**
+- Create: `src/components/landing/HeroCell.tsx`
+- Create: `src/components/landing/HeroCell.test.tsx`
+
+- [ ] **Step 1: Write the failing HeroCell test**
+
+Create `src/components/landing/HeroCell.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import HeroCell from './HeroCell';
+
+const noop = () => {};
+
+describe('HeroCell', () => {
+  it('renders the env chip + headline + cursor', () => {
+    render(<HeroCell connecting={false} onConnectSolflare={noop} onUseAnotherWallet={noop} />);
+    expect(screen.getByText(/env \/ mainnet-beta/i)).toBeInTheDocument();
+    expect(screen.getByText('Type. Sign.')).toBeInTheDocument();
+    // Second headline span is "Done" + KamiCursor — its textContent is "Done▌".
+    // Use a regex anchored to the start to disambiguate from the parent h1
+    // whose textContent collapses both spans.
+    expect(screen.getByText(/^Done/)).toBeInTheDocument();
+    expect(screen.getByText('▌')).toBeInTheDocument();
+  });
+
+  it('renders the subhead with klend-sdk highlighted in mono amber', () => {
+    render(<HeroCell connecting={false} onConnectSolflare={noop} onUseAnotherWallet={noop} />);
+    const klend = screen.getByText('klend-sdk');
+    expect(klend).toBeInTheDocument();
+    expect(klend.tagName).toBe('CODE');
+    expect(klend).toHaveClass('text-kami-amber');
+  });
+
+  it('renders the mock agent input prompt', () => {
+    render(<HeroCell connecting={false} onConnectSolflare={noop} onUseAnotherWallet={noop} />);
+    expect(screen.getByText(/find best USDC yield/i)).toBeInTheDocument();
+  });
+
+  it('fires onConnectSolflare when the CTA is clicked', () => {
+    const onConnectSolflare = vi.fn();
+    render(
+      <HeroCell connecting={false} onConnectSolflare={onConnectSolflare} onUseAnotherWallet={noop} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /connect with solflare/i }));
+    expect(onConnectSolflare).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onUseAnotherWallet when the secondary link is clicked', () => {
+    const onUseAnotherWallet = vi.fn();
+    render(
+      <HeroCell connecting={false} onConnectSolflare={noop} onUseAnotherWallet={onUseAnotherWallet} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /use another solana wallet/i }));
+    expect(onUseAnotherWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "Opening Solflare…" + disables the CTA when connecting=true', () => {
+    render(<HeroCell connecting={true} onConnectSolflare={noop} onUseAnotherWallet={noop} />);
+    const cta = screen.getByRole('button', { name: /opening solflare/i });
+    expect(cta).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test:run src/components/landing/HeroCell.test.tsx
+```
+
+Expected: FAIL — `Cannot find module './HeroCell'`.
+
+- [ ] **Step 3: Implement HeroCell**
+
+Create `src/components/landing/HeroCell.tsx`:
+
+```tsx
+import { Code2, Wallet } from 'lucide-react';
+import BentoCell from './BentoCell';
+import KamiCursor from './KamiCursor';
+
+interface Props {
+  connecting: boolean;
+  onConnectSolflare: () => void;
+  onUseAnotherWallet: () => void;
+}
+
+export default function HeroCell({ connecting, onConnectSolflare, onUseAnotherWallet }: Props) {
+  return (
+    <BentoCell
+      delay={1}
+      className="col-span-12 lg:col-span-8 lg:row-span-2 rounded-[2rem] flex flex-col gap-8 lg:gap-12 min-h-[24rem] lg:min-h-[28rem]"
+      as="section"
+    >
+      <div className="flex-1 flex flex-col gap-6">
+        <span className="self-start inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-kami-sepiaBg border border-kami-cellBorder font-mono text-xs text-kami-creamMuted">
+          <Code2 className="w-3.5 h-3.5" aria-hidden="true" />
+          env / mainnet-beta
+        </span>
+        <h1 className="font-display font-bold tracking-tight text-kami-cream text-5xl sm:text-6xl lg:text-7xl xl:text-[5rem] leading-[0.95]">
+          <span className="block">Type. Sign.</span>
+          <span className="block">
+            Done
+            <KamiCursor />
+          </span>
+        </h1>
+        <p className="font-sans text-kami-cream/80 text-lg lg:text-xl max-w-xl leading-relaxed">
+          Speak plain English. Kami parses your intent, calls Kamino{' '}
+          <code className="font-mono text-kami-amber not-italic">klend-sdk</code> primitives, and
+          queues a mainnet transaction. No dashboard scraping required.
+        </p>
+      </div>
+
+      <div className="border-t border-kami-cellBorder/50 pt-6 flex flex-col sm:flex-row sm:items-center gap-4 justify-between">
+        <div className="font-mono text-sm text-kami-creamMuted px-4 py-3 rounded-xl bg-kami-sepiaBg/60 border border-kami-cellBorder">
+          <span className="text-kami-amber/80">&gt; </span>find best USDC yield
+        </div>
+        <div className="flex flex-col gap-2 sm:items-end">
+          <button
+            type="button"
+            onClick={onConnectSolflare}
+            disabled={connecting}
+            className="inline-flex items-center gap-3 px-6 py-3 rounded-xl bg-kami-amber text-kami-sepiaBg font-mono uppercase tracking-wider text-sm font-bold hover:opacity-95 active:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-wait"
+          >
+            <Wallet className="w-5 h-5" aria-hidden="true" />
+            {connecting ? 'Opening Solflare…' : 'Connect with Solflare'}
+          </button>
+          <button
+            type="button"
+            onClick={onUseAnotherWallet}
+            className="text-xs text-kami-creamMuted hover:text-kami-cream transition-colors"
+          >
+            Use another Solana wallet
+          </button>
+        </div>
+      </div>
+    </BentoCell>
+  );
+}
+```
+
+- [ ] **Step 4: Run HeroCell test**
+
+```bash
+pnpm test:run src/components/landing/HeroCell.test.tsx
+```
+
+Expected: PASS — 6 tests.
+
+- [ ] **Step 5: Run full test suite + typechecks**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm test:run
+```
+
+Expected: client typecheck silent. All tests PASS (198 + 6 new = 204).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/landing/HeroCell.tsx src/components/landing/HeroCell.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(landing): add HeroCell with Solflare CTA
+
+Sprint 5 Day 18, Task 3 of 7. The 8-col × 2-row hero cell that anchors
+the bento. env chip + Unbounded display headline (Type. Sign. Done▌) +
+Inter subhead with klend-sdk in mono amber + bordered mock agent prompt
+("> find best USDC yield") + amber-bg Connect with Solflare CTA with
+Wallet icon + secondary "Use another Solana wallet" link.
+
+Wallet wiring stays in the parent (EmptyState owns useWallet +
+useWalletModal); HeroCell takes plain props (onConnectSolflare /
+onUseAnotherWallet / connecting) so it stays pure and easy to test.
+
+6 new vitest cases.
+EOF
+)"
+```
+
+---
+
+### Task 4: SysMetricsCell + LatestTxCell
+
+**Files:**
+- Create: `src/components/landing/SysMetricsCell.tsx`
+- Create: `src/components/landing/SysMetricsCell.test.tsx`
+- Create: `src/components/landing/LatestTxCell.tsx`
+- Create: `src/components/landing/LatestTxCell.test.tsx`
+
+- [ ] **Step 1: Write the failing SysMetricsCell test**
+
+Create `src/components/landing/SysMetricsCell.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import SysMetricsCell from './SysMetricsCell';
+import { LANDING_STATS } from '../../lib/landing-content';
+
+describe('SysMetricsCell', () => {
+  it('renders the sys.metrics header', () => {
+    render(<SysMetricsCell delay={2} />);
+    expect(screen.getByText('sys.metrics')).toBeInTheDocument();
+  });
+
+  it('renders all 4 metric keys + values from LANDING_STATS', () => {
+    render(<SysMetricsCell delay={2} />);
+    LANDING_STATS.forEach((stat) => {
+      expect(screen.getByText(stat.key)).toBeInTheDocument();
+      expect(screen.getByText(stat.value)).toBeInTheDocument();
+    });
+  });
+
+  it('renders the highlighted value (sys.tools_loaded) in amber', () => {
+    render(<SysMetricsCell delay={2} />);
+    const highlighted = LANDING_STATS.find((s) => s.highlight)!;
+    expect(screen.getByText(highlighted.value)).toHaveClass('text-kami-amber');
+  });
+
+  it('renders non-highlighted values in cream', () => {
+    render(<SysMetricsCell delay={2} />);
+    const nonHighlighted = LANDING_STATS.find((s) => !s.highlight)!;
+    expect(screen.getByText(nonHighlighted.value)).toHaveClass('text-kami-cream');
+  });
+});
+```
+
+The tests reference `LANDING_STATS` directly instead of literal strings (`'186 suite'`, `'7 active'`, etc.) — when the test count drifts in `landing-content.ts`, the test still passes because both sides of the assertion update together. The test's intent is "the component renders the data," not "the component renders this exact value."
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test:run src/components/landing/SysMetricsCell.test.tsx
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement SysMetricsCell**
+
+Create `src/components/landing/SysMetricsCell.tsx`:
+
+```tsx
+import { Cpu } from 'lucide-react';
+import BentoCell from './BentoCell';
+import { LANDING_STATS } from '../../lib/landing-content';
+
+interface Props {
+  delay: number;
+}
+
+export default function SysMetricsCell({ delay }: Props) {
+  return (
+    <BentoCell delay={delay} className="col-span-12 md:col-span-6 lg:col-span-4">
+      <div className="flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-kami-creamMuted mb-6">
+        <Cpu className="w-4 h-4" aria-hidden="true" />
+        sys.metrics
+      </div>
+      <ul className="flex flex-col">
+        {LANDING_STATS.map((stat, i) => (
+          <li
+            key={stat.key}
+            className={[
+              'flex justify-between items-baseline py-3 font-mono text-sm group',
+              i < LANDING_STATS.length - 1 ? 'border-b border-kami-cellBorder/50' : '',
+            ].join(' ')}
+          >
+            <span className="text-kami-creamMuted">{stat.key}</span>
+            <span
+              className={[
+                'transition-transform duration-200 ease-smooth group-hover:translate-x-[1px]',
+                stat.highlight ? 'text-kami-amber font-bold' : 'text-kami-cream',
+              ].join(' ')}
+            >
+              {stat.value}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </BentoCell>
+  );
+}
+```
+
+- [ ] **Step 4: Run SysMetricsCell test**
+
+```bash
+pnpm test:run src/components/landing/SysMetricsCell.test.tsx
+```
+
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Write the failing LatestTxCell test**
+
+Create `src/components/landing/LatestTxCell.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import LatestTxCell from './LatestTxCell';
+import { LATEST_TX } from '../../lib/landing-content';
+
+describe('LatestTxCell', () => {
+  it('renders the log.latest_tx header + Confirmed pill', () => {
+    render(<LatestTxCell delay={3} />);
+    expect(screen.getByText('log.latest_tx')).toBeInTheDocument();
+    expect(screen.getByText('Confirmed')).toBeInTheDocument();
+  });
+
+  it('renders the truncated signature', () => {
+    render(<LatestTxCell delay={3} />);
+    expect(screen.getByText(LATEST_TX.shortSignature)).toBeInTheDocument();
+  });
+
+  it('renders the action description', () => {
+    render(<LatestTxCell delay={3} />);
+    expect(screen.getByText(LATEST_TX.action)).toBeInTheDocument();
+  });
+
+  it('Solscan link points to the full signature with safe target/rel', () => {
+    render(<LatestTxCell delay={3} />);
+    const link = screen.getByRole('link', { name: /view on solscan/i });
+    expect(link).toHaveAttribute('href', LATEST_TX.solscanUrl);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+```bash
+pnpm test:run src/components/landing/LatestTxCell.test.tsx
+```
+
+Expected: FAIL.
+
+- [ ] **Step 7: Implement LatestTxCell**
+
+Create `src/components/landing/LatestTxCell.tsx`:
+
+```tsx
+import { ArrowLeftRight, ArrowUpRight, Check } from 'lucide-react';
+import BentoCell from './BentoCell';
+import { LATEST_TX } from '../../lib/landing-content';
+
+interface Props {
+  delay: number;
+}
+
+export default function LatestTxCell({ delay }: Props) {
+  return (
+    <BentoCell
+      delay={delay}
+      className="col-span-12 md:col-span-6 lg:col-span-4 bg-kami-cellElevated"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-kami-creamMuted">
+          <ArrowLeftRight className="w-4 h-4" aria-hidden="true" />
+          log.latest_tx
+        </div>
+        <span className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-kami-amberHaze border border-kami-amber/40 text-kami-amber font-mono text-[10px] uppercase tracking-wider">
+          <Check className="w-3 h-3" aria-hidden="true" />
+          Confirmed
+        </span>
+      </div>
+      <div className="rounded-xl border border-kami-cellBorder bg-kami-sepiaBg/40 p-4 flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-mono text-[11px] uppercase tracking-wider text-kami-creamMuted">
+            Signature
+          </span>
+          <a
+            href={LATEST_TX.solscanUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="View on Solscan"
+            className="font-mono text-sm text-kami-cream hover:text-kami-amber transition-colors inline-flex items-center gap-1"
+          >
+            {LATEST_TX.shortSignature}
+            <ArrowUpRight className="w-3.5 h-3.5" aria-hidden="true" />
+          </a>
+        </div>
+        <hr className="border-kami-cellBorder/50" />
+        <div className="flex items-center gap-3">
+          <span className="w-2 h-2 rounded-full bg-kami-amber flex-shrink-0" aria-hidden="true" />
+          <span className="font-sans text-sm text-kami-cream/90">{LATEST_TX.action}</span>
+        </div>
+      </div>
+    </BentoCell>
+  );
+}
+```
+
+- [ ] **Step 8: Run LatestTxCell test**
+
+```bash
+pnpm test:run src/components/landing/LatestTxCell.test.tsx
+```
+
+Expected: PASS — 4 tests.
+
+- [ ] **Step 9: Run full test suite + typechecks**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm test:run
+```
+
+Expected: client typecheck silent. All tests PASS (204 + 8 new = 212).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/components/landing/SysMetricsCell.tsx src/components/landing/SysMetricsCell.test.tsx src/components/landing/LatestTxCell.tsx src/components/landing/LatestTxCell.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(landing): add SysMetricsCell + LatestTxCell
+
+Sprint 5 Day 18, Task 4 of 7. The two right-column side cells of the
+bento.
+
+- SysMetricsCell — 4 mono key/value rows from LANDING_STATS, hairline
+  separators, and a hover translateX nudge on values. The proudest
+  stat (sys.tools_loaded) renders amber; the rest stay cream.
+- LatestTxCell — slightly elevated bg (cellElevated), Confirmed pill,
+  truncated signature with ↗ Solscan link (target=_blank +
+  rel=noopener noreferrer), and the "5 USDC supplied to Kamino"
+  action with an amber bullet.
+
+8 new vitest cases.
+EOF
+)"
+```
+
+---
+
+### Task 5: ToolCell with 4-instance wiring
+
+**Files:**
+- Create: `src/components/landing/ToolCell.tsx`
+- Create: `src/components/landing/ToolCell.test.tsx`
+
+- [ ] **Step 1: Write the failing ToolCell test**
+
+Create `src/components/landing/ToolCell.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ToolCell from './ToolCell';
+import { TOOL_CELLS } from '../../lib/landing-content';
+
+describe('ToolCell', () => {
+  it('renders name + description + hint', () => {
+    const tool = TOOL_CELLS[0]; // tool/findYield
+    render(<ToolCell tool={tool} delay={4} />);
+    expect(screen.getByText(tool.name)).toBeInTheDocument();
+    expect(screen.getByText(tool.description)).toBeInTheDocument();
+    expect(screen.getByText(tool.hint)).toBeInTheDocument();
+  });
+
+  it('renders an icon (lucide svg)', () => {
+    const { container } = render(<ToolCell tool={TOOL_CELLS[0]} delay={4} />);
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders all 4 TOOL_CELLS by name when mapped', () => {
+    render(
+      <>
+        {TOOL_CELLS.map((t, i) => (
+          <ToolCell key={t.name} tool={t} delay={4 + i} />
+        ))}
+      </>,
+    );
+    expect(screen.getByText('tool/findYield')).toBeInTheDocument();
+    expect(screen.getByText('tool/getPortfolio')).toBeInTheDocument();
+    expect(screen.getByText('tool/simulateHealth')).toBeInTheDocument();
+    expect(screen.getByText('tool/buildSign')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test:run src/components/landing/ToolCell.test.tsx
+```
+
+Expected: FAIL — `Cannot find module './ToolCell'`.
+
+- [ ] **Step 3: Implement ToolCell**
+
+Create `src/components/landing/ToolCell.tsx`:
+
+```tsx
+import {
+  FolderOpen,
+  Wallet,
+  ShieldCheck,
+  PenLine,
+  type LucideIcon,
+} from 'lucide-react';
+import BentoCell from './BentoCell';
+import type { ToolCellData, ToolIconKey } from '../../lib/landing-content';
+
+const ICON_MAP: Record<ToolIconKey, LucideIcon> = {
+  findYield: FolderOpen,
+  getPortfolio: Wallet,
+  simulateHealth: ShieldCheck,
+  buildSign: PenLine,
+};
+
+interface Props {
+  tool: ToolCellData;
+  delay: number;
+}
+
+export default function ToolCell({ tool, delay }: Props) {
+  const Icon = ICON_MAP[tool.iconKey];
+  return (
+    <BentoCell
+      delay={delay}
+      className="col-span-12 sm:col-span-6 lg:col-span-3 flex flex-col gap-3 group"
+    >
+      <div className="flex items-center gap-2 font-mono text-sm text-kami-amber">
+        <Icon className="w-4 h-4" aria-hidden="true" />
+        {tool.name}
+      </div>
+      <p className="font-sans text-sm text-kami-cream/80 leading-relaxed flex-1">
+        {tool.description}
+      </p>
+      <div className="font-mono text-[11px] text-kami-creamMuted px-3 py-2 rounded-lg border border-kami-cellBorder bg-kami-sepiaBg/40 group-hover:border-kami-amber/40 transition-colors">
+        {tool.hint}
+      </div>
+    </BentoCell>
+  );
+}
+```
+
+- [ ] **Step 4: Run ToolCell test**
+
+```bash
+pnpm test:run src/components/landing/ToolCell.test.tsx
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Run full test suite + typechecks**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm test:run
+```
+
+Expected: client typecheck silent. All tests PASS (212 + 3 new = 215).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/landing/ToolCell.tsx src/components/landing/ToolCell.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(landing): add ToolCell
+
+Sprint 5 Day 18, Task 5 of 7. The tile that renders one Kamino tool —
+icon + amber mono name + description + bordered impl-hint chip. Used 4
+times in the bento (findYield / getPortfolio / simulateHealth /
+buildSign). Icons mapped from Lucide (FolderOpen / Wallet / ShieldCheck
+/ PenLine) keyed off the iconKey field in TOOL_CELLS.
+
+The hint chip's border turns amber on parent-cell hover (group-hover)
+to echo BentoCell's hover language.
+
+3 new vitest cases.
+EOF
+)"
+```
+
+---
+
+### Task 6: PipelineCell + SponsorStrip
+
+**Files:**
+- Create: `src/components/landing/PipelineCell.tsx`
+- Create: `src/components/landing/PipelineCell.test.tsx`
+- Create: `src/components/landing/SponsorStrip.tsx`
+- Create: `src/components/landing/SponsorStrip.test.tsx`
+
+- [ ] **Step 1: Write the failing PipelineCell test**
+
+Create `src/components/landing/PipelineCell.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import PipelineCell from './PipelineCell';
+
+describe('PipelineCell', () => {
+  it('renders all 3 step labels', () => {
+    render(<PipelineCell delay={8} />);
+    expect(screen.getByText('INTENT')).toBeInTheDocument();
+    expect(screen.getByText('SIGNATURE')).toBeInTheDocument();
+    expect(screen.getByText('EXECUTION')).toBeInTheDocument();
+  });
+
+  it('renders all 3 step indices in [N/3] form', () => {
+    render(<PipelineCell delay={8} />);
+    expect(screen.getByText('[1/3]')).toBeInTheDocument();
+    expect(screen.getByText('[2/3]')).toBeInTheDocument();
+    expect(screen.getByText('[3/3]')).toBeInTheDocument();
+  });
+
+  it('renders 3 lucide svg icons (one per step)', () => {
+    const { container } = render(<PipelineCell delay={8} />);
+    expect(container.querySelectorAll('svg')).toHaveLength(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test:run src/components/landing/PipelineCell.test.tsx
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement PipelineCell**
+
+Create `src/components/landing/PipelineCell.tsx`:
+
+```tsx
+import { Terminal, PenLine, CheckCircle2, type LucideIcon } from 'lucide-react';
+import BentoCell from './BentoCell';
+import { PIPELINE_STEPS, type PipelineIconKey } from '../../lib/landing-content';
+
+const ICON_MAP: Record<PipelineIconKey, LucideIcon> = {
+  intent: Terminal,
+  signature: PenLine,
+  execution: CheckCircle2,
+};
+
+interface Props {
+  delay: number;
+}
+
+export default function PipelineCell({ delay }: Props) {
+  return (
+    <BentoCell
+      delay={delay}
+      className="col-span-12 border-dashed lg:p-10"
+    >
+      <div className="relative flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div
+          className="hidden lg:block absolute left-0 right-0 top-1/2 h-px bg-kami-cellBorder"
+          aria-hidden="true"
+        />
+        {PIPELINE_STEPS.map((step) => {
+          const Icon = ICON_MAP[step.iconKey];
+          return (
+            <div
+              key={step.label}
+              className="relative flex items-center gap-4 px-6 py-4 rounded-xl bg-kami-sepiaBg/60 border border-kami-cellBorder hover:border-kami-amber/40 transition-colors group"
+            >
+              <Icon className="w-6 h-6 text-kami-amber" aria-hidden="true" />
+              <div className="flex flex-col gap-0.5">
+                <span className="font-mono text-[10px] text-kami-creamMuted group-hover:text-kami-amber transition-colors">
+                  [{step.index}]
+                </span>
+                <span className="font-mono text-sm font-bold uppercase tracking-wider text-kami-cream">
+                  {step.label}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </BentoCell>
+  );
+}
+```
+
+- [ ] **Step 4: Run PipelineCell test**
+
+```bash
+pnpm test:run src/components/landing/PipelineCell.test.tsx
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Write the failing SponsorStrip test**
+
+Create `src/components/landing/SponsorStrip.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import SponsorStrip from './SponsorStrip';
+import { SPONSORS } from '../../lib/landing-content';
+
+describe('SponsorStrip', () => {
+  it('renders all 5 sponsor wordmarks', () => {
+    render(<SponsorStrip />);
+    SPONSORS.forEach((s) => {
+      expect(screen.getByText(s)).toBeInTheDocument();
+    });
+  });
+
+  it('renders sponsors in the canonical order', () => {
+    const { container } = render(<SponsorStrip />);
+    const text = container.textContent ?? '';
+    const indices = SPONSORS.map((s) => text.indexOf(s));
+    const sorted = [...indices].sort((a, b) => a - b);
+    expect(indices).toEqual(sorted);
+  });
+});
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+```bash
+pnpm test:run src/components/landing/SponsorStrip.test.tsx
+```
+
+Expected: FAIL.
+
+- [ ] **Step 7: Implement SponsorStrip**
+
+Create `src/components/landing/SponsorStrip.tsx`:
+
+```tsx
+import { Fragment } from 'react';
+import { SPONSORS } from '../../lib/landing-content';
+
+export default function SponsorStrip() {
+  return (
+    <div
+      className="col-span-12 py-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-3 opacity-50 grayscale hover:opacity-100 hover:grayscale-0 transition-all duration-500 ease-smooth"
+      aria-label="Sponsors"
+    >
+      {SPONSORS.map((name, i) => (
+        <Fragment key={name}>
+          <span className="font-display font-bold uppercase tracking-widest text-sm text-kami-cream">
+            {name}
+          </span>
+          {i < SPONSORS.length - 1 ? (
+            <span aria-hidden="true" className="text-kami-amber/40">
+              ·
+            </span>
+          ) : null}
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+```
+
+`<Fragment>` keeps each sponsor span as a direct child of the outer `<div>`, so each sponsor's span has `textContent === name` exactly — `screen.getByText(name)` finds a single match. (Wrapping each pair in a `<span>` would make the LAST sponsor's outer wrapper share the same textContent as its inner span, throwing RTL's "multiple elements" error.)
+
+- [ ] **Step 8: Run SponsorStrip test**
+
+```bash
+pnpm test:run src/components/landing/SponsorStrip.test.tsx
+```
+
+Expected: PASS — 2 tests.
+
+- [ ] **Step 9: Run full test suite + typechecks**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm test:run
+```
+
+Expected: client typecheck silent. All tests PASS (215 + 5 new = 220).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/components/landing/PipelineCell.tsx src/components/landing/PipelineCell.test.tsx src/components/landing/SponsorStrip.tsx src/components/landing/SponsorStrip.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(landing): add PipelineCell + SponsorStrip
+
+Sprint 5 Day 18, Task 6 of 7. The two full-width strip cells at the
+bottom of the bento.
+
+- PipelineCell — full-width dashed-border strip showing the 3-step
+  flow [1/3] INTENT → [2/3] SIGNATURE → [3/3] EXECUTION. Each step
+  sits on a sepia-bg card; on lg+ a hairline track-line runs across
+  the cell behind the cards. Step indices turn amber on hover.
+- SponsorStrip — text-only Eitherway · Kamino · Solflare · Helius ·
+  Vercel wordmarks (Unbounded display, uppercase, tracking-widest).
+  Initial state is 50% opacity + grayscale; hovering the strip
+  removes both for a soft reveal. No anchors in v1 — adding sponsor
+  links is a follow-up if RECTOR wants.
+
+5 new vitest cases.
+EOF
+)"
+```
+
+---
+
+### Task 7: EmptyState integration + tests refresh + ChatPanel cleanup + mobile QA
+
+**Files:**
+- Modify: `src/components/EmptyState.tsx` (full rewrite)
+- Modify: `src/components/EmptyState.test.tsx` (refresh)
+- Modify: `src/components/ChatPanel.tsx` (drop `onSend` prop on `<EmptyState>`)
+
+- [ ] **Step 1: Write the new EmptyState integration test (will fail until rewrite is done)**
+
+Replace the entire contents of `src/components/EmptyState.test.tsx` with:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LATEST_TX, SPONSORS, TOOL_CELLS } from '../lib/landing-content';
+
+const setVisible = vi.fn();
+const solflareConnect = vi.fn();
+
+vi.mock('@solana/wallet-adapter-react', () => ({
+  useWallet: () => ({
+    connected: false,
+    connecting: false,
+    wallets: [
+      {
+        adapter: {
+          name: 'Solflare',
+          connect: solflareConnect,
+        },
+      },
+    ],
+  }),
+}));
+
+vi.mock('@solana/wallet-adapter-react-ui', () => ({
+  useWalletModal: () => ({ setVisible }),
+}));
+
+import EmptyState from './EmptyState';
+
+describe('EmptyState bento landing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the hero headline', () => {
+    render(<EmptyState />);
+    expect(screen.getByText('Type. Sign.')).toBeInTheDocument();
+    expect(screen.getByText(/^Done/)).toBeInTheDocument();
+  });
+
+  it('renders all 4 tool cells by name', () => {
+    render(<EmptyState />);
+    TOOL_CELLS.forEach((t) => {
+      expect(screen.getByText(t.name)).toBeInTheDocument();
+    });
+  });
+
+  it('renders the latest tx truncated signature', () => {
+    render(<EmptyState />);
+    expect(screen.getByText(LATEST_TX.shortSignature)).toBeInTheDocument();
+  });
+
+  it('renders all 5 sponsor wordmarks', () => {
+    render(<EmptyState />);
+    SPONSORS.forEach((s) => {
+      expect(screen.getByText(s)).toBeInTheDocument();
+    });
+  });
+
+  it('renders the 3 pipeline step labels', () => {
+    render(<EmptyState />);
+    expect(screen.getByText('INTENT')).toBeInTheDocument();
+    expect(screen.getByText('SIGNATURE')).toBeInTheDocument();
+    expect(screen.getByText('EXECUTION')).toBeInTheDocument();
+  });
+
+  it('clicking the CTA calls solflare.adapter.connect()', () => {
+    render(<EmptyState />);
+    fireEvent.click(screen.getByRole('button', { name: /connect with solflare/i }));
+    expect(solflareConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking "Use another Solana wallet" opens the wallet modal', () => {
+    render(<EmptyState />);
+    fireEvent.click(screen.getByRole('button', { name: /use another solana wallet/i }));
+    expect(setVisible).toHaveBeenCalledWith(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test:run src/components/EmptyState.test.tsx
+```
+
+Expected: FAIL — multiple cases (old `EmptyState` doesn't render any of the bento content).
+
+- [ ] **Step 3: Rewrite EmptyState.tsx as the bento composer**
+
+Replace the entire contents of `src/components/EmptyState.tsx` with:
+
+```tsx
+import { useWallet } from '@solana/wallet-adapter-react';
+import { useWalletModal } from '@solana/wallet-adapter-react-ui';
+import HeroCell from './landing/HeroCell';
+import SysMetricsCell from './landing/SysMetricsCell';
+import LatestTxCell from './landing/LatestTxCell';
+import ToolCell from './landing/ToolCell';
+import PipelineCell from './landing/PipelineCell';
+import SponsorStrip from './landing/SponsorStrip';
+import { TOOL_CELLS } from '../lib/landing-content';
+
+const SOLFLARE_WALLET_NAME = 'Solflare';
+const SOLFLARE_INSTALL_URL = 'https://solflare.com/download';
+
+export default function EmptyState() {
+  const { connected, connecting, wallets } = useWallet();
+  const { setVisible } = useWalletModal();
+
+  const handleConnectSolflare = async () => {
+    if (connected || connecting) return;
+    const solflare = wallets.find((w) => w.adapter.name === SOLFLARE_WALLET_NAME);
+    if (!solflare) {
+      window.open(SOLFLARE_INSTALL_URL, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    try {
+      await solflare.adapter.connect();
+    } catch {
+      setVisible(true);
+    }
+  };
+
+  const handleUseAnotherWallet = () => setVisible(true);
+
+  return (
+    <div className="flex-1 overflow-y-auto bg-kami-sepiaBg text-kami-cream relative">
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          backgroundImage:
+            'linear-gradient(to right, rgba(245,230,211,0.03) 1px, transparent 1px), linear-gradient(to bottom, rgba(245,230,211,0.03) 1px, transparent 1px)',
+          backgroundSize: '32px 32px',
+        }}
+        aria-hidden="true"
+      />
+      <div
+        className="absolute -top-32 -left-32 w-[600px] h-[600px] rounded-full bg-kami-amberHaze blur-3xl pointer-events-none"
+        aria-hidden="true"
+      />
+
+      <div className="relative max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-8 py-8 lg:py-12">
+        <div className="flex items-center justify-between font-mono text-xs text-kami-creamMuted uppercase tracking-wider mb-6 lg:mb-10">
+          <span>&gt; KAMI · v1.0 · MAINNET</span>
+          <span className="inline-flex items-center gap-2">
+            [sys.status: online]
+            <span
+              className="w-2 h-2 rounded-full bg-kami-amber animate-pulse-dot"
+              aria-hidden="true"
+            />
+          </span>
+        </div>
+
+        <div className="grid grid-cols-12 gap-3 lg:gap-4">
+          <HeroCell
+            connecting={connecting}
+            onConnectSolflare={handleConnectSolflare}
+            onUseAnotherWallet={handleUseAnotherWallet}
+          />
+          <SysMetricsCell delay={2} />
+          <LatestTxCell delay={3} />
+          {TOOL_CELLS.map((tool, i) => (
+            <ToolCell key={tool.name} tool={tool} delay={4 + i} />
+          ))}
+          <PipelineCell delay={8} />
+          <SponsorStrip />
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Update ChatPanel.tsx to drop the `onSend` prop on `<EmptyState>`**
+
+In `src/components/ChatPanel.tsx`, line 65, change:
+
+```tsx
+        <EmptyState onSend={handleSend} />
+```
+
+to:
+
+```tsx
+        <EmptyState />
+```
+
+- [ ] **Step 5: Run EmptyState test + full suite + typechecks**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm test:run
+```
+
+Expected:
+- client typecheck silent
+- server typecheck silent
+- EmptyState.test.tsx PASS — 7 tests (refreshed; old 5 replaced)
+- Full suite PASS (220 + 7 - 5 = 222 — net +2 from EmptyState refresh, +14 from earlier tasks)
+
+If `ChatMessage.test.tsx` or `ChatPanel`-adjacent tests reference `onSend` flowing into `EmptyState`, they will fail — none expected based on the grep, but verify here.
+
+- [ ] **Step 6: Mobile + browser QA**
+
+Start dev server and verify in a browser:
+
+```bash
+pnpm dev
+```
+
+Then open `http://localhost:5173/` and:
+
+1. **Desktop (≥ lg, 1280px+):** Hero spans 8 columns × 2 rows; SysMetrics + LatestTx stack in the right 4 columns; 4 tool cells in one row across 12 columns (3 cols each); PipelineCell + SponsorStrip full-width.
+2. **Tablet (md, 768-1023px):** Hero collapses to 12-col, single row; SysMetrics + LatestTx side-by-side (6+6); tool cells 2x2 (6+6 per row); pipeline + sponsor full-width.
+3. **Mobile (375-767px):** Everything stacks single-column. No horizontal scroll. Pipeline steps stack vertically.
+4. **Animation:** Cells cascade in over ~1s on first load. Cursor blinks. Header dot pulses.
+5. **CTA flow:** Click "Connect with Solflare" — Solflare popup opens (or install page if no Solflare). Click "Use another Solana wallet" — wallet adapter modal opens.
+6. **Hover:** Cells lift + amber border + glow. Stat values translate +1px on hover. Tool hint chips' borders turn amber. Sponsor strip de-grayscales.
+7. **Once connected:** EmptyState disappears (ChatPanel switches to chat surfaces). Reload the page disconnected and re-verify the bento.
+
+If any cell breaks at a specific breakpoint, fix the col-span / row-span / flex direction inline. Re-run tests after each fix.
+
+- [ ] **Step 7: Final commit**
+
+```bash
+git add src/components/EmptyState.tsx src/components/EmptyState.test.tsx src/components/ChatPanel.tsx
+git commit -m "$(cat <<'EOF'
+feat(landing): wire bento landing into EmptyState + drop onSend prop
+
+Sprint 5 Day 18, Task 7 of 7 — final integration. EmptyState becomes a
+pure composer: outer wrapper with the sepia bg + 32px grid pattern +
+ambient amber blur, an overline header (KAMI · v1.0 · MAINNET +
+sys.status pulse), and a 12-col grid that places HeroCell (8×2) +
+SysMetricsCell (4) + LatestTxCell (4) + 4 ToolCells (3 each) +
+PipelineCell (12) + SponsorStrip (12). Wallet wiring (useWallet +
+useWalletModal) stays here; HeroCell receives plain handler props.
+
+EmptyState no longer needs an onSend prop — the bento's tool cells are
+non-clickable info displays per spec §5.4. Drop the prop from both
+EmptyState's interface and ChatPanel's call site. Visitors who want to
+type queries do so via ChatInput post-connect.
+
+EmptyState.test.tsx refreshed: the 5 old feature-card-onSend cases
+replaced with 7 integration smoke cases that verify the bento
+composes (hero / 4 tools / latest tx / 5 sponsors / 3 pipeline steps)
+plus the two CTA paths (Solflare connect + wallet-modal fallback).
+Net test count: 186 → 222 (+36).
+EOF
+)"
+```
+
+- [ ] **Step 8: Push the branch + open PR**
+
+```bash
+git push -u origin docs/landing-bento-amber-spec
+gh pr create --title "feat(landing): bento amber pre-connect landing redesign" --body "$(cat <<'EOF'
+## Summary
+
+Replaces the minimal `EmptyState.tsx` (gradient K logo + 4 feature cards + CTA) with a full bento-grid pre-connect landing in an amber-on-sepia palette.
+
+- Spec: `docs/superpowers/specs/2026-04-28-kami-landing-bento-amber-design.md`
+- Plan: `docs/superpowers/plans/2026-04-28-kami-landing-bento-amber-implementation.md`
+- 8 new components under `src/components/landing/`
+- New Tailwind theme tokens (kami.sepiaBg / cellBase / cellElevated / cream / amber / etc.)
+- Unbounded display font added; JetBrains Mono bumped to weight 700
+- `src/lib/landing-content.ts` centralizes the 4 stats / latest tx / 5 sponsors / 4 tool cells / 3 pipeline steps
+
+## Behavior changes
+
+- Tool cells are non-clickable info displays per spec §5.4 (was: 4 clickable feature cards firing sample queries via `onSend`). Visitors type queries via `ChatInput` post-connect.
+- The chat shell (ChatPanel / Sidebar / ChatInput / ChatMessage / SignTransactionCard) is unchanged. Restyling to amber lands in a follow-up spec.
+
+## Tests
+
+- 186 → 222 (+36 across 9 new test files + 1 refreshed)
+- All 3 typechecks (client + server + project-mode `tsc -b`) green
+
+## Test plan
+
+- [ ] Lighthouse perf ≥ 90 on the landing
+- [ ] Manual mobile QA at 375px width — no horizontal scroll, every cell stacks cleanly
+- [ ] Manual desktop QA at 1280px — hero 8×2, side cells stacked, 4 tool cells in one row
+- [ ] CTA flow: Connect with Solflare → wallet popup → connected → chat shell
+- [ ] Use another Solana wallet → wallet adapter modal
+- [ ] Cascade animation runs once on load; no animation jank on resize
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+After all 7 tasks are committed and the PR is open, the self-review checklist:
+
+1. **Spec coverage**: All 11 spec sections covered. §3 visual (palette + typography + animation + bg) → Task 1. §4 layout → Task 7 grid. §5 cells → Tasks 3-6. §6 implementation strategy → matches the file structure above. §9 success criteria → mobile QA in Task 7 step 6.
+2. **Type consistency**: `ToolCellData`, `ToolIconKey`, `PipelineStep`, `PipelineIconKey`, `LatestTx`, `LandingStat` all defined once in `landing-content.ts` and re-used by component props.
+3. **No placeholders**: every step has the full code. Every test has explicit assertions.
+4. **TDD discipline**: each task is RED → GREEN → COMMIT. 9 test files, never code-before-test.
+5. **One commit per task**: 7 commits, each isolating a single logical change.
+
+## Risks / mitigations
+
+- **Cascade animation perception** on slow devices: 800ms × 1s stagger = ~1.8s before all cells settle. Acceptable for a landing first-impression but could feel slow on a refresh. If RECTOR finds it sluggish, drop stagger to 50ms and total to 600ms in Task 1's keyframe + Task 2's BentoCell delay multiplier.
+- **Lighthouse perf**: Unbounded adds ~30 KB. If perf drops below 90, switch Unbounded to `display=swap` (already set in Task 1 Step 6) and consider self-hosting or `font-display: optional` if it's still a problem.
+- **Test count drift**: spec §6.6 hardcodes `186 suite` in `LANDING_STATS`. After this PR ships, the live count is 222. The display string `186 suite` becomes stale. Acceptable for v1 (centralized in `landing-content.ts`); follow-up: add a build-time stat-injection script or accept the drift until the next refresh.
+- **Solflare popup blocked**: if the user's browser blocks the popup, `solflare.adapter.connect()` rejects → `catch` falls through to `setVisible(true)` (existing behavior preserved).
+
+## Effort estimate
+
+- Task 1: 30 min
+- Task 2: 30 min
+- Task 3: 1.5 h
+- Task 4: 1 h
+- Task 5: 45 min
+- Task 6: 45 min
+- Task 7: 1 h (incl. mobile QA)
+- Total: ~5.5 h, within spec §10's 5-7h window.

--- a/docs/superpowers/specs/2026-04-28-kami-landing-bento-amber-design.md
+++ b/docs/superpowers/specs/2026-04-28-kami-landing-bento-amber-design.md
@@ -1,0 +1,310 @@
+# Kami Landing — Bento + Amber Design Spec
+
+**Date:** 2026-04-28
+**Author:** RECTOR + CIPHER
+**Status:** Approved (pending implementation plan)
+**Related:** PR #42 (README rewrite), Eitherway Track Frontier 2026 bounty (deadline 2026-05-12)
+
+---
+
+## 1. Goal
+
+Replace the current minimal `EmptyState.tsx` (gradient K logo + "Welcome to Kami" + 4 feature cards + Connect with Solflare CTA) with a **richer pre-connect landing experience** in a bento-grid layout using an amber-on-sepia palette. The landing should feel like a confident production AI/DeFi product — not a scaffolded hackathon empty state — and earn a strong first impression from bounty judges browsing `kami.rectorspace.com` before they connect a wallet.
+
+## 2. Why
+
+- The current empty state is informationally thin (4 generic feature cards + Connect CTA).
+- Bounty judges score live dApp working + UX quality; a polished pre-connect surface is high-leverage signal.
+- README rewrite (PR #42) gave Kami strong GitHub-side marketing; the live URL needs equivalent polish for visitors who land directly.
+- The aidesigner-generated v3 prototype validated the direction — bento grid + amber palette + chat/AI-native vocabulary. RECTOR signed off on v3 (this spec captures that decision).
+
+## 3. Visual identity
+
+### 3.1 Color palette (A3 — amber on sepia)
+
+| Token | Hex | Usage |
+|------|------|-------|
+| `kami-bg` | `#1a1410` | Body background. Warm sepia. |
+| `kami-cell-base` | `#221a14` | Default bento cell background (slightly elevated from body). |
+| `kami-cell-elevated` | `#2a2117` | Hover state for cells; also the more-elevated variant. |
+| `kami-text` | `#F5E6D3` | Primary text (cream). |
+| `kami-text-muted` | `rgba(245, 230, 211, 0.6)` | Secondary text, mono labels. |
+| `kami-border` | `rgba(245, 230, 211, 0.12)` | Hairline cell borders. |
+| `kami-amber` | `#FFA500` | Accent: CTA, data emphasis, cursor blink, hover-border, sponsor highlight. |
+| `kami-amber-glow` | `rgba(255, 165, 0, 0.15)` | Drop-shadow on hover. |
+| `kami-amber-15` | `rgba(255, 165, 0, 0.05)` | Ambient bg blur tint. |
+
+Solana brand semantics: amber `#FFA500` is close to (but not identical to) Solflare's `#FCA311`. The visual closeness lets the Connect CTA stay on-brand for Solflare without a separate brand color. Direct Solflare reference (e.g., wallet adapter logo) keeps the canonical Solflare orange `#FCA311`; everything else uses Kami amber `#FFA500`.
+
+### 3.2 Typography
+
+| Family | Source | Usage |
+|--------|--------|-------|
+| **Unbounded** (700/800) | Google Fonts | Display headline (`Type. Sign. Done▌`) and section headers. Geometric, distinctive. |
+| **Inter** (400/500) | Google Fonts | Body text. Already in Kami stack. |
+| **JetBrains Mono** (400/500/700) | Google Fonts | All technical / data text: addresses, signatures, stat keys, tool names, label overlines, `> ` prompts, code references. |
+
+Drop the Bricolage Grotesque face that aidesigner included in v2 — Unbounded covers the display role; Inter handles everything else; mono covers data. Three families is enough.
+
+### 3.3 Animation
+
+- **`▌` cursor blink** — 1s `step-end infinite` opacity flip, amber color. Anchored to the end of the hero headline (`Done▌`).
+- **Pulse-dot** — `box-shadow` 2s ease-out infinite, on the `[sys.status: online]` indicator dot in the header.
+- **Cascade-up entrance** — cells animate in from `translateY(20px) opacity:0` over 800ms with `cubic-bezier(0.175, 0.885, 0.32, 1.275)` (gentle bounce). Staggered 100ms between cells (`--delay: 1, 2, 3, …`). Total stagger ~1.0s.
+- **Hover lift** — cells `-translate-y-[2px]`, border shifts from `cream-border` to `amber/40`, drop-shadow `0_10px_40px_-20px_rgba(255,165,0,0.15)`, transition 500ms `cubic-bezier(0.4, 0, 0.2, 1)`.
+- **No parallax / scroll-triggered animations**. Keep it static after entrance.
+
+### 3.4 Background
+
+- Body: warm sepia `#1a1410` with a 32px grid pattern at `rgba(245, 230, 211, 0.03)` opacity (subtle structural feel, not noise).
+- Single ambient amber blur (600px diameter, `120px` blur, `5%` opacity) anchored at top-left for warmth.
+- No gradients, photos, illustrations, or video.
+
+## 4. Layout
+
+12-column bento grid, max-width 1280px. On `lg:` breakpoint and up, the structure is:
+
+```
+┌──────────────────────────────────────────┬───────────────────┐
+│                                            │                   │
+│   HERO CELL                                 │   SYS.METRICS     │
+│   (col-span-8, row-span-2, ~480-560px tall) │   (col-span-4)    │
+│                                            │                   │
+│                                            ├───────────────────┤
+│                                            │                   │
+│                                            │   LOG.LATEST_TX   │
+│                                            │   (col-span-4)    │
+│                                            │                   │
+├──────────┬──────────┬──────────┬───────────┴───────────────────┤
+│          │          │          │                               │
+│ tool/A   │ tool/B   │ tool/C   │ tool/D                        │
+│ (3 cols) │ (3 cols) │ (3 cols) │ (3 cols)                      │
+├──────────┴──────────┴──────────┴───────────────────────────────┤
+│                                                                 │
+│   PIPELINE                                                      │
+│   (col-span-12, dashed-border, [1/3] → [2/3] → [3/3])           │
+├─────────────────────────────────────────────────────────────────┤
+│   SPONSOR STRIP — Eitherway · Kamino · Solflare · Helius · ...  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Header overline** above the grid: `> KAMI · v1.0 · MAINNET` left, `[sys.status: online] •` (pulsing amber dot) right.
+
+**Mobile** (`< md:`): all cells stack vertically full-width. The hero cell loses its 2-row span. The 4 tool cells become a 2x2 grid on `md:` then full-stack on smaller screens. The pipeline cell's 3 steps stack vertically with `→` arrows between.
+
+## 5. Cell-by-cell content
+
+### 5.1 HERO cell
+
+Top section (vertically anchored top):
+- Environment chip: `[code-icon] env / mainnet-beta` — small mono chip, sepia-900 bg, cream-border outline.
+- Headline (Unbounded display, clamp 5xl→7xl→[5rem]):
+
+  ```
+  Type. Sign.
+  Done▌
+  ```
+
+  The `▌` is the blinking amber cursor.
+
+- Subhead (Inter body, lg→xl):
+
+  > Speak plain English. Kami parses your intent, calls Kamino `klend-sdk` primitives, and queues a mainnet transaction. No dashboard scraping required.
+
+  `klend-sdk` rendered as inline mono in amber.
+
+Bottom section (vertically anchored bottom, separated by a `border-t border-cream-border/50` rule):
+- Left: a fake "Agent Input" mono prompt field — `> find best USDC yield` — that visually echoes the chat input the user will get post-connect.
+- Right: CTA button. **Label: `Connect with Solflare`** (NOT v3's `Init Session`; revert to the Solflare-explicit naming for sponsor alignment). Wallet icon (Phosphor `ph-wallet` or Lucide `Wallet`), uppercase mono, amber bg, sepia-900 text, rounded-xl, hover scales/changes bg slightly.
+
+### 5.2 `sys.metrics` cell (top-right)
+
+- Header row: `[cpu-icon] sys.metrics` (mono label, cream-muted color).
+- 4 metric rows, each a flex `justify-between` line, mono text, `border-b cream-border/20` between them:
+
+| Key | Value | Notes |
+|---|---|---|
+| `sys.tools_loaded` | `7 active` | amber color (it's the proudest stat) |
+| `ci.tests_passing` | `186 suite` | cream (high contrast but not amber — keep amber sparing) |
+| `net.roundtrips` | `3 mainnet` | cream |
+| `sys.genesis` | `2026-04-19` | cream |
+
+Hover on each row: value translates `+1px` right.
+
+### 5.3 `log.latest_tx` cell (bottom-right)
+
+Slightly more elevated bg than other cells (`sepia-900/30`) so it reads as a featured proof-of-life.
+
+- Header row: `[arrows-icon] log.latest_tx` left, `[check-icon] Confirmed` chip right (amber-tinted bg, amber-bordered, amber text, mono uppercase).
+- Body: a nested card (`sepia-800` bg + `cream-border`) containing two stacked field-value pairs separated by a horizontal rule:
+  - `Signature` → `5XKeETjGfm…UpvZE` mono cream link with `↗` external-link icon. Links to Solscan.
+  - `Action` → bullet (amber dot) + `5 USDC supplied to Kamino` body text.
+
+Use the actual Day-6 mainnet signature `5XKeETjGfmj9jEWUNCKcf8u49bY4hEzX2a7JcB4nPxQCBbmZ7ipoNrgTXQMJWXHvKw7Bsera9xxYygLVxLUpUvZE` (already cited in README's Proof of Life section + `docs/kamino-integration.md`).
+
+### 5.4 Tool cells (×4)
+
+Each cell renders one Kamino tool. **Pick the four most demoable tools** (skip the `build*` cousins to avoid repetition):
+
+| Cell | Display name | Description (1 line) | Implementation hint (mono small) |
+|---|---|---|---|
+| 1 | `tool/findYield` | Scans Kamino reserves for highest supply / borrow APY. | `→ KaminoMarket.reserves` |
+| 2 | `tool/getPortfolio` | Fetches connected wallet's positions, debt, health factor. | `→ KaminoMarket.getObligationByAddress` |
+| 3 | `tool/simulateHealth` | Projects post-action health factor before signing. | `→ Obligation.simulateBorrowAndWithdrawAction` |
+| 4 | `tool/buildSign` | Builds + signs deposit / borrow / withdraw / repay v0 transactions. | `→ KaminoAction.build*Txns` |
+
+`tool/buildSign` is a generic umbrella for the 4 `build*` Kamino tools. The detail "4 build variants" is exposed in `docs/kamino-integration.md` and can be teased in a tooltip on hover; the landing keeps the count clean at 4 cells.
+
+Each cell layout:
+- Top: `[folder-icon] tool/<name>` mono amber.
+- Middle: 1-line description in cream/80.
+- Bottom: implementation hint mono in `cream-muted` inside a small bordered chip.
+
+Hover: the chip border turns amber.
+
+### 5.5 PIPELINE cell
+
+Full-width, 2px-dashed border (visually distinct from the solid-bordered cells), interior padding generous.
+
+3-step horizontal flow with a horizontal track-line behind (`1px` solid `kami-border` running across the cell at vertical center):
+
+| Step | Label | Icon |
+|---|---|---|
+| `[1/3]` | `INTENT` | `[terminal-window]` amber |
+| `[2/3]` | `SIGNATURE` | `[pen-nib]` amber |
+| `[3/3]` | `EXECUTION` | `[check-circle]` amber |
+
+Each step sits on a sepia-800 bg "card" that breaks the track-line where it crosses, giving the visual impression of stepping stones across a wire.
+
+Hover on each step: bracket numeral turns amber.
+
+### 5.6 SPONSOR strip
+
+Full-width, `py-8`, no border. Initial state `opacity-50` + `grayscale`. On hover (entire strip): grayscale removes, opacity full, 500ms transition.
+
+Wordmarks (text only, no logo files): `Eitherway · Kamino · Solflare · Helius · Vercel`. Display font (Unbounded), uppercase, tracking-widest, separated by amber dots (`amber/40` color).
+
+Note: in v3 aidesigner included Anthropic but I removed it here — Anthropic powers the LLM but isn't a bounty-track sponsor; keeping the list aligned with the README's bounty acknowledgments.
+
+### 5.7 Footer (no change pre-connect)
+
+Today's pre-connect view (`EmptyState.tsx`) does NOT show a disclaimer footer — the disclaimer ("Kami provides information only. Always verify before signing transactions.") lives below `ChatInput`, which only renders post-connect. The bento landing preserves this: no disclaimer footer pre-connect (there's nothing to sign yet). After-connect, the existing disclaimer stays unchanged in this spec; restyle to amber lands in the chat-shell follow-up spec.
+
+## 6. Implementation strategy
+
+### 6.1 Where the bento landing lives
+
+`src/components/EmptyState.tsx` is the entry point. Today it returns a `<div>` with the K logo, heading, 4 feature cards, and Connect CTA. **The new bento landing fully replaces this component's body**.
+
+The bento renders only when `connected === false` (existing condition; preserved). When `connected === true`, the chat shell (ChatPanel + Sidebar + ChatInput + ChatMessage) takes over — same as today. **The chat surfaces themselves are NOT redesigned in this spec** (separate scope, separate spec if needed).
+
+### 6.2 Tailwind theme additions
+
+Update `tailwind.config.ts` `theme.extend.colors` with the new tokens (kami-bg, kami-cell-base, kami-cell-elevated, kami-text, kami-text-muted, kami-border, kami-amber, kami-amber-glow). Keep existing `kami-accent` purple for backward compatibility during the transition; mark it deprecated in a comment and remove in a follow-up after the chat shell is also restyled (out of scope for this spec).
+
+Add `theme.extend.fontFamily`:
+- `display: ['Unbounded', 'sans-serif']`
+- `mono: ['JetBrains Mono', 'monospace']` (overrides Tailwind's default mono stack)
+
+Add `theme.extend.transitionTimingFunction`:
+- `'spring': 'cubic-bezier(0.175, 0.885, 0.32, 1.275)'`
+- `'smooth': 'cubic-bezier(0.4, 0, 0.2, 1)'`
+
+Add the `cascade-up`, `blink`, and `pulse-dot` keyframes to `tailwind.config.ts` `theme.extend.keyframes` + `animation` (proper Tailwind plugin form, NOT inline `<style>` tags — we're shipping React, not the prototype HTML).
+
+### 6.3 Font loading
+
+Add Google Fonts `<link>` tags to `index.html` for Unbounded (700/800) and JetBrains Mono (400/500/700). Inter is already loaded.
+
+### 6.4 Icons
+
+Kami already uses **Lucide React** (`lucide-react` package). v3 prototype uses **Phosphor Icons** because aidesigner picked it. **For the React port, use Lucide equivalents** — keep the dep tree clean.
+
+| Phosphor (v3) | Lucide React (port) |
+|---|---|
+| `ph-code` | `Code2` |
+| `ph-cpu` | `Cpu` |
+| `ph-arrows-left-right` | `ArrowLeftRight` |
+| `ph-folder-open` | `FolderOpen` |
+| `ph-terminal-window` | `Terminal` |
+| `ph-pen-nib` | `PenLine` |
+| `ph-check-circle` | `CheckCircle2` |
+| `ph-check` (in Confirmed pill) | `Check` |
+| `ph-arrow-up-right` | `ArrowUpRight` |
+| `ph-wallet` (CTA) | `Wallet` |
+| `ph-arrow-right` (mobile pipeline) | `ArrowRight` |
+
+### 6.5 Component decomposition
+
+Split `EmptyState.tsx` into smaller components for clarity:
+
+- `EmptyState.tsx` — top-level layout + the bento grid.
+- `BentoCell.tsx` — shared cell wrapper with hover, cascade animation, border + bg styling. Takes `delay`, `className`, `children` props.
+- `HeroCell.tsx` — the big hero cell content (env chip, headline, subhead, mock prompt, CTA).
+- `SysMetricsCell.tsx` — the 4-row stats list. Takes `metrics` prop (key/value/highlight tuples).
+- `LatestTxCell.tsx` — the proof-of-life card. Takes `signature`, `action`, `solscanUrl` props.
+- `ToolCell.tsx` — single tool. Takes `name`, `description`, `hint`, `icon` props. Used 4 times.
+- `PipelineCell.tsx` — the 3-step strip. Static content.
+- `SponsorStrip.tsx` — wordmarks. Static.
+- `KamiCursor.tsx` — `<span class="cursor-blink">▌</span>` extracted as a tiny component for reuse (will also appear in chat input post-connect, in a follow-up).
+
+The cascade animation delay is sequenced at the bento grid level (each cell receives a `delay` prop 1..10), keeping the animation choreography in one place.
+
+### 6.6 Hardcoded vs dynamic data
+
+- **Hardcoded for v1**: `sys.metrics` values (7 / 186 / 3 / 2026-04-19), the latest tx signature + action, sponsor list.
+- **Dynamic deferred**: dynamic test count, dynamic latest mainnet tx (read from a future mainnet activity log endpoint), dynamic uptime. None of this exists yet; spec it as future work.
+
+The hardcoded values must match the README + integration docs. Centralize them in a `src/lib/landing-content.ts` constants file so future updates touch one place.
+
+## 7. Out of scope
+
+This spec covers the **pre-connect landing block only**. Explicitly NOT in scope:
+
+- Chat shell redesign (ChatPanel, Sidebar, ChatInput, ChatMessage, SignTransactionCard) — they keep their current purple `kami-accent` styling. A follow-up spec will redesign the chat shell to match the amber palette so the post-connect experience cohereres with the landing.
+- Mobile sidebar redesign.
+- Animation choreography between landing → chat (e.g., the bento collapsing as the wallet connects). For v1, the page simply re-renders into the chat shell — no transition.
+- Theme switcher (light mode). Dark only.
+- Marketing logos for sponsors. Text wordmarks only.
+- Dynamic stats / latest tx fetching. Hardcoded for v1.
+- Internationalization. English only.
+
+## 8. Open questions / decisions during implementation
+
+1. **CTA copy** — final call: `Connect with Solflare` (sponsor-aligned, recommended) vs `Init Session` (chat/AI native, what v3 used). Spec recommends `Connect with Solflare`; flag if RECTOR prefers `Init Session`.
+2. **Cell border-radius** — v3 uses `1.5rem` (lg+) / `2rem`. Confirm or tighten to a more conservative `0.75rem` for less "rounded modern" feel.
+3. **Latest tx solscan URL** — confirm the Day-6 deposit `5XKee...UpvZE` is the right showcase tx (vs the deposit→repay→withdraw round-trip ones in `docs/kamino-integration.md` Hero Moment section).
+4. **Tool cell hint format** — "→ klend.getReserves()" style (v3) vs "klend.getReserves()" without the arrow vs "import { KaminoMarket } from '@kamino-finance/klend-sdk'" full import. Spec says go with the short arrow form.
+5. **Sponsor link on click** — v1 leaves them as text-only (no anchor). Add anchor links to each sponsor's site (eitherway.ai, kamino.finance, solflare.com, helius.dev, vercel.com)?
+
+## 9. Success criteria
+
+- Visitor lands on `kami.rectorspace.com` (not connected), sees the bento landing, immediately understands "this is an AI co-pilot for Kamino on Solana that produces signed mainnet transactions."
+- All 4 tool cells visually communicate the tool's purpose without requiring the visitor to click anything.
+- The CTA path (Connect with Solflare → wallet popup → connected → chat shell) works identically to today; no auth regression.
+- Mobile (375px width) renders without horizontal scroll, all cells stack cleanly.
+- Lighthouse performance ≥ 90 (the landing block adds Google Fonts + ~200 lines of JSX; no large bundles).
+- Tests: `EmptyState.tsx` regression tests pass; new tests for `HeroCell.tsx` (CTA fires onConnect), `LatestTxCell.tsx` (renders signature + opens Solscan), `ToolCell.tsx` (all 4 instances render their props correctly).
+- All existing tests stay green (186 → 186+).
+- No new ESLint warnings.
+- Accessibility: every interactive element keyboard-navigable; `aria-label` on icon-only buttons; color contrast meets WCAG AA on amber-on-sepia for both primary and disabled states.
+
+## 10. Estimated implementation effort
+
+- Tailwind theme + font loading: ~30 min.
+- 7 new components (BentoCell + HeroCell + SysMetricsCell + LatestTxCell + ToolCell + PipelineCell + SponsorStrip): ~3-4 hours.
+- Refactor `EmptyState.tsx` to use the new components: ~30 min.
+- Tests: ~1-2 hours (5 new test files, ~10-15 new test cases).
+- QA pass + mobile responsive fixes: ~30 min - 1 hour.
+- Total: **5-7 hours** of implementation work, post-spec.
+
+## 11. References
+
+- aidesigner v3 prototype HTML: `.superpowers/brainstorm/50873-1777364130/content/design-v3.html` (run_id `dc556226-35e4-477b-be6a-4bfbcf5087af`)
+- Earlier iterations:
+  - v1 (osovault DNA, too-similar): run_id `1c4e9ca0-6f95-4f9b-a448-5f4ea05c37a6`
+  - v2 (vocabulary refresh, structurally still osovault): run_id `2af3542b-909b-40a7-8b6c-540ae67ccfa5`
+- Layout decision: bento grid (vs conversation-first vs IDE) — RECTOR picked bento.
+- Palette decision: A3 amber on sepia (vs original osovault yellow, electric yellow, mustard, neon, etc.) — RECTOR picked A3.
+- Inspiration site: osovault.xyz (DNA, NOT structural copy)
+- Total aidesigner credits spent during exploration: 3 (1c4e9ca0 + 2af3542b + dc556226). Remaining balance: 74.

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <title>Kami — AI DeFi Co-Pilot</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Unbounded:wght@700;800&display=swap" rel="stylesheet" />
   </head>
   <body class="bg-[#0a0a0f] text-[#e2e8f0] antialiased">
     <div id="root"></div>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mutable wallet mock so each test can vary `connected` state. Hoisted so
+// the mock factory below can reference it without a temporal dead-zone.
+const mockWallet = vi.hoisted(() => ({
+  connected: false,
+  connecting: false,
+  wallets: [],
+  publicKey: null,
+}));
+
+vi.mock('@solana/wallet-adapter-react', () => ({
+  useWallet: () => mockWallet,
+}));
+
+vi.mock('@solana/wallet-adapter-react-ui', () => ({
+  useWalletModal: () => ({ setVisible: vi.fn() }),
+  WalletMultiButton: () => null,
+}));
+
+vi.mock('@vercel/analytics/react', () => ({ Analytics: () => null }));
+vi.mock('@vercel/speed-insights/react', () => ({ SpeedInsights: () => null }));
+
+vi.mock('./components/WalletProvider', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./hooks/useChat', () => ({
+  useChat: () => ({
+    conversations: [{ id: 'c1', title: 'first chat', messages: [], createdAt: 1, updatedAt: 1 }],
+    activeConversation: {
+      id: 'c1',
+      title: 'first chat',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1,
+    },
+    activeId: 'c1',
+    isStreaming: false,
+    sendMessage: vi.fn(),
+    stopStreaming: vi.fn(),
+    newConversation: vi.fn(),
+    switchConversation: vi.fn(),
+    deleteConversation: vi.fn(),
+    clearAllConversations: vi.fn(),
+    renameConversation: vi.fn(),
+  }),
+}));
+
+import App from './App';
+
+describe('App connect-gating', () => {
+  beforeEach(() => {
+    mockWallet.connected = false;
+    mockWallet.connecting = false;
+  });
+
+  it('renders the full-screen bento landing when wallet is not connected', () => {
+    mockWallet.connected = false;
+    render(<App />);
+    expect(screen.getByText('Type. Sign.')).toBeInTheDocument();
+  });
+
+  it('does NOT render the bento landing when wallet is connected', () => {
+    mockWallet.connected = true;
+    render(<App />);
+    expect(screen.queryByText('Type. Sign.')).not.toBeInTheDocument();
+  });
+
+  it('renders the chat shell (Sidebar + ChatPanel) when wallet is connected', () => {
+    mockWallet.connected = true;
+    render(<App />);
+    // ChatPanel header shows the activeConversation title from the useChat mock.
+    // Multiple matches expected (Sidebar list + ChatPanel header), so use getAllByText.
+    expect(screen.getAllByText('first chat').length).toBeGreaterThan(0);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
+import { useWallet } from '@solana/wallet-adapter-react';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/react';
 import SolanaWalletProvider from './components/WalletProvider';
 import Sidebar from './components/Sidebar';
 import ChatPanel from './components/ChatPanel';
+import EmptyState from './components/EmptyState';
 import { useChat } from './hooks/useChat';
 
 function AppContent() {
+  const { connected } = useWallet();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const {
     conversations,
@@ -21,6 +24,14 @@ function AppContent() {
     clearAllConversations,
     renameConversation,
   } = useChat();
+
+  if (!connected) {
+    return (
+      <div className="flex h-screen bg-kami-sepiaBg text-kami-cream overflow-hidden">
+        <EmptyState />
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-screen bg-kami-bg text-kami-text overflow-hidden">

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -4,7 +4,6 @@ import { WalletMultiButton } from '@solana/wallet-adapter-react-ui';
 import type { Conversation } from '../types';
 import ChatMessageComponent from './ChatMessage';
 import ChatInput from './ChatInput';
-import EmptyState from './EmptyState';
 
 interface Props {
   conversation: Conversation;
@@ -62,7 +61,7 @@ export default function ChatPanel({ conversation, isStreaming, onSend, onStop, o
           </div>
         </div>
       ) : (
-        <EmptyState />
+        <div className="flex-1" />
       )}
 
       {/* Input */}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -62,7 +62,7 @@ export default function ChatPanel({ conversation, isStreaming, onSend, onStop, o
           </div>
         </div>
       ) : (
-        <EmptyState onSend={handleSend} />
+        <EmptyState />
       )}
 
       {/* Input */}

--- a/src/components/EmptyState.test.tsx
+++ b/src/components/EmptyState.test.tsx
@@ -1,54 +1,77 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LATEST_TX, SPONSORS, TOOL_CELLS } from '../lib/landing-content';
+
+const setVisible = vi.fn();
+const solflareConnect = vi.fn();
 
 vi.mock('@solana/wallet-adapter-react', () => ({
-  useWallet: () => ({ connected: false, connecting: false, wallets: [] }),
+  useWallet: () => ({
+    connected: false,
+    connecting: false,
+    wallets: [
+      {
+        adapter: {
+          name: 'Solflare',
+          connect: solflareConnect,
+        },
+      },
+    ],
+  }),
 }));
 
 vi.mock('@solana/wallet-adapter-react-ui', () => ({
-  useWalletModal: () => ({ setVisible: vi.fn() }),
+  useWalletModal: () => ({ setVisible }),
 }));
 
 import EmptyState from './EmptyState';
 
-describe('EmptyState feature cards', () => {
+describe('EmptyState bento landing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('renders all 4 feature card titles', () => {
-    render(<EmptyState onSend={vi.fn()} />);
-    expect(screen.getByText('Live Yields')).toBeInTheDocument();
-    expect(screen.getByText('Build & Sign')).toBeInTheDocument();
-    expect(screen.getByText('Portfolio')).toBeInTheDocument();
-    expect(screen.getByText('Health Sim')).toBeInTheDocument();
+  it('renders the hero headline', () => {
+    render(<EmptyState />);
+    expect(screen.getByText('Type. Sign.')).toBeInTheDocument();
+    expect(screen.getByText(/^Done/)).toBeInTheDocument();
   });
 
-  it('fires the Live Yields query on click', () => {
-    const onSend = vi.fn();
-    render(<EmptyState onSend={onSend} />);
-    fireEvent.click(screen.getByText('Live Yields').closest('button')!);
-    expect(onSend).toHaveBeenCalledWith('What are the best Kamino yields right now?');
+  it('renders all 4 tool cells by name', () => {
+    render(<EmptyState />);
+    TOOL_CELLS.forEach((t) => {
+      expect(screen.getByText(t.name)).toBeInTheDocument();
+    });
   });
 
-  it('fires the Build & Sign query on click', () => {
-    const onSend = vi.fn();
-    render(<EmptyState onSend={onSend} />);
-    fireEvent.click(screen.getByText('Build & Sign').closest('button')!);
-    expect(onSend).toHaveBeenCalledWith('Show me a 5 USDC deposit example');
+  it('renders the latest tx truncated signature', () => {
+    render(<EmptyState />);
+    expect(screen.getByText(LATEST_TX.shortSignature)).toBeInTheDocument();
   });
 
-  it('fires the Portfolio query on click', () => {
-    const onSend = vi.fn();
-    render(<EmptyState onSend={onSend} />);
-    fireEvent.click(screen.getByText('Portfolio').closest('button')!);
-    expect(onSend).toHaveBeenCalledWith('Show me my Kamino portfolio');
+  it('renders all 5 sponsor wordmarks', () => {
+    render(<EmptyState />);
+    SPONSORS.forEach((s) => {
+      expect(screen.getByText(s)).toBeInTheDocument();
+    });
   });
 
-  it('fires the Health Sim query on click', () => {
-    const onSend = vi.fn();
-    render(<EmptyState onSend={onSend} />);
-    fireEvent.click(screen.getByText('Health Sim').closest('button')!);
-    expect(onSend).toHaveBeenCalledWith('Will my borrow position liquidate at SOL $50?');
+  it('renders the 3 pipeline step labels', () => {
+    render(<EmptyState />);
+    expect(screen.getByText('INTENT')).toBeInTheDocument();
+    expect(screen.getByText('SIGNATURE')).toBeInTheDocument();
+    expect(screen.getByText('EXECUTION')).toBeInTheDocument();
+  });
+
+  it('clicking the CTA calls solflare.adapter.connect()', () => {
+    render(<EmptyState />);
+    fireEvent.click(screen.getByRole('button', { name: /connect with solflare/i }));
+    expect(solflareConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking "Use another Solana wallet" opens the wallet modal', () => {
+    render(<EmptyState />);
+    fireEvent.click(screen.getByRole('button', { name: /use another solana wallet/i }));
+    expect(setVisible).toHaveBeenCalledWith(true);
   });
 });

--- a/src/components/EmptyState.test.tsx
+++ b/src/components/EmptyState.test.tsx
@@ -3,20 +3,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LATEST_TX, SPONSORS, TOOL_CELLS } from '../lib/landing-content';
 
 const setVisible = vi.fn();
-const solflareConnect = vi.fn();
+const select = vi.fn();
+
+const walletState = vi.hoisted(() => ({
+  wallets: [{ adapter: { name: 'Solflare' } }] as Array<{ adapter: { name: string } }>,
+}));
 
 vi.mock('@solana/wallet-adapter-react', () => ({
   useWallet: () => ({
     connected: false,
     connecting: false,
-    wallets: [
-      {
-        adapter: {
-          name: 'Solflare',
-          connect: solflareConnect,
-        },
-      },
-    ],
+    wallets: walletState.wallets,
+    select,
   }),
 }));
 
@@ -29,6 +27,7 @@ import EmptyState from './EmptyState';
 describe('EmptyState bento landing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    walletState.wallets = [{ adapter: { name: 'Solflare' } }];
   });
 
   it('renders the hero headline', () => {
@@ -63,10 +62,28 @@ describe('EmptyState bento landing', () => {
     expect(screen.getByText('EXECUTION')).toBeInTheDocument();
   });
 
-  it('clicking the CTA calls solflare.adapter.connect()', () => {
+  it('clicking the CTA calls select("Solflare") to drive WalletProvider autoConnect', () => {
+    // Calling adapter.connect() directly (the previous approach) connects the
+    // wallet but bypasses WalletProvider's walletName → adapter binding, so
+    // useWallet().connected stays false. select() is the proper API.
     render(<EmptyState />);
     fireEvent.click(screen.getByRole('button', { name: /connect with solflare/i }));
-    expect(solflareConnect).toHaveBeenCalledTimes(1);
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(select).toHaveBeenCalledWith('Solflare');
+  });
+
+  it('clicking the CTA opens the install URL when Solflare is not detected', () => {
+    walletState.wallets = [];
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<EmptyState />);
+    fireEvent.click(screen.getByRole('button', { name: /connect with solflare/i }));
+    expect(open).toHaveBeenCalledWith(
+      'https://solflare.com/download',
+      '_blank',
+      'noopener,noreferrer'
+    );
+    expect(select).not.toHaveBeenCalled();
+    open.mockRestore();
   });
 
   it('clicking "Use another Solana wallet" opens the wallet modal', () => {

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,28 +1,17 @@
-import React from 'react';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { useWalletModal } from '@solana/wallet-adapter-react-ui';
-import { TrendingUp, ArrowLeftRight, Wallet, ShieldCheck, type LucideIcon } from 'lucide-react';
+import HeroCell from './landing/HeroCell';
+import SysMetricsCell from './landing/SysMetricsCell';
+import LatestTxCell from './landing/LatestTxCell';
+import ToolCell from './landing/ToolCell';
+import PipelineCell from './landing/PipelineCell';
+import SponsorStrip from './landing/SponsorStrip';
+import { TOOL_CELLS } from '../lib/landing-content';
 
 const SOLFLARE_WALLET_NAME = 'Solflare';
 const SOLFLARE_INSTALL_URL = 'https://solflare.com/download';
 
-function SolflareLogo({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 32 32" className={className} aria-hidden="true">
-      <circle cx="16" cy="16" r="16" fill="#FFFFFF" fillOpacity="0.12" />
-      <path
-        d="M11.5 9h6.2c2.9 0 4.6 1.7 4.6 4.4 0 2.1-1.1 3.6-3 4.1l3.3 5.5h-3.2l-3-5.2h-2.2V23H11.5V9zm6.1 6.3c1.4 0 2.3-.8 2.3-2 0-1.3-.9-2-2.3-2h-2.9v4h2.9z"
-        fill="#FCA311"
-      />
-    </svg>
-  );
-}
-
-interface Props {
-  onSend: (msg: string) => void;
-}
-
-export default function EmptyState({ onSend }: Props) {
+export default function EmptyState() {
   const { connected, connecting, wallets } = useWallet();
   const { setVisible } = useWalletModal();
 
@@ -40,79 +29,50 @@ export default function EmptyState({ onSend }: Props) {
     }
   };
 
+  const handleUseAnotherWallet = () => setVisible(true);
+
   return (
-    <div className="flex-1 flex items-center justify-center p-8">
-      <div className="text-center max-w-md">
-        <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-kami-accent to-purple-400 flex items-center justify-center text-white font-bold text-2xl mx-auto mb-6">
-          K
-        </div>
-        <h2 className="text-xl font-semibold text-white mb-2">Welcome to Kami</h2>
-        <p className="text-sm text-kami-muted mb-8 leading-relaxed">
-          Your AI co-pilot for Kamino Finance on Solana. Ask about your obligations, find yield,
-          simulate health factors, or deposit / borrow / withdraw — all in plain English.
-        </p>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-left mb-6">
-          {(
-            [
-              {
-                Icon: TrendingUp,
-                title: 'Live Yields',
-                desc: 'Find best APYs on Kamino',
-                query: 'What are the best Kamino yields right now?',
-              },
-              {
-                Icon: ArrowLeftRight,
-                title: 'Build & Sign',
-                desc: 'Deposit, borrow, withdraw, repay',
-                query: 'Show me a 5 USDC deposit example',
-              },
-              {
-                Icon: Wallet,
-                title: 'Portfolio',
-                desc: 'Your Kamino positions + APY',
-                query: 'Show me my Kamino portfolio',
-              },
-              {
-                Icon: ShieldCheck,
-                title: 'Health Sim',
-                desc: 'Liquidation-risk checks',
-                query: 'Will my borrow position liquidate at SOL $50?',
-              },
-            ] satisfies Array<{ Icon: LucideIcon; title: string; desc: string; query: string }>
-          ).map(({ Icon, title, desc, query }) => (
-            <button
-              key={title}
-              type="button"
-              onClick={() => onSend(query)}
-              className="text-left p-3 rounded-xl border border-kami-border bg-kami-surface/50 hover:bg-kami-surface transition-colors cursor-pointer"
-            >
-              <Icon className="w-5 h-5 text-kami-accent mb-2" aria-hidden="true" />
-              <div className="text-sm font-medium text-white">{title}</div>
-              <div className="text-xs text-kami-muted">{desc}</div>
-            </button>
-          ))}
+    <div className="flex-1 overflow-y-auto bg-kami-sepiaBg text-kami-cream relative">
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          backgroundImage:
+            'linear-gradient(to right, rgba(245,230,211,0.03) 1px, transparent 1px), linear-gradient(to bottom, rgba(245,230,211,0.03) 1px, transparent 1px)',
+          backgroundSize: '32px 32px',
+        }}
+        aria-hidden="true"
+      />
+      <div
+        className="absolute -top-32 -left-32 w-[600px] h-[600px] rounded-full bg-kami-amberHaze blur-3xl pointer-events-none"
+        aria-hidden="true"
+      />
+
+      <div className="relative max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-8 py-8 lg:py-12">
+        <div className="flex items-center justify-between font-mono text-xs text-kami-creamMuted uppercase tracking-wider mb-6 lg:mb-10">
+          <span>&gt; KAMI · v1.0 · MAINNET</span>
+          <span className="inline-flex items-center gap-2">
+            [sys.status: online]
+            <span
+              className="w-2 h-2 rounded-full bg-kami-amber animate-pulse-dot"
+              aria-hidden="true"
+            />
+          </span>
         </div>
 
-        {!connected && (
-          <button
-            type="button"
-            onClick={handleConnectSolflare}
-            disabled={connecting}
-            className="w-full flex items-center justify-center gap-3 px-6 py-3 rounded-xl bg-gradient-to-r from-[#FCA311] to-[#E8920D] text-black font-semibold hover:opacity-95 active:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-wait"
-          >
-            <SolflareLogo className="w-5 h-5" />
-            {connecting ? 'Opening Solflare…' : 'Connect with Solflare'}
-          </button>
-        )}
-        {!connected && (
-          <button
-            type="button"
-            onClick={() => setVisible(true)}
-            className="mt-2 w-full text-xs text-kami-muted hover:text-kami-text transition-colors"
-          >
-            Use another Solana wallet
-          </button>
-        )}
+        <div className="grid grid-cols-12 gap-3 lg:gap-4">
+          <HeroCell
+            connecting={connecting}
+            onConnectSolflare={handleConnectSolflare}
+            onUseAnotherWallet={handleUseAnotherWallet}
+          />
+          <SysMetricsCell delay={2} />
+          <LatestTxCell delay={3} />
+          {TOOL_CELLS.map((tool, i) => (
+            <ToolCell key={tool.name} tool={tool} delay={4 + i} />
+          ))}
+          <PipelineCell delay={8} />
+          <SponsorStrip />
+        </div>
       </div>
     </div>
   );

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -12,21 +12,21 @@ const SOLFLARE_WALLET_NAME = 'Solflare';
 const SOLFLARE_INSTALL_URL = 'https://solflare.com/download';
 
 export default function EmptyState() {
-  const { connected, connecting, wallets } = useWallet();
+  const { connected, connecting, wallets, select } = useWallet();
   const { setVisible } = useWalletModal();
 
-  const handleConnectSolflare = async () => {
+  const handleConnectSolflare = () => {
     if (connected || connecting) return;
     const solflare = wallets.find((w) => w.adapter.name === SOLFLARE_WALLET_NAME);
     if (!solflare) {
       window.open(SOLFLARE_INSTALL_URL, '_blank', 'noopener,noreferrer');
       return;
     }
-    try {
-      await solflare.adapter.connect();
-    } catch {
-      setVisible(true);
-    }
+    // select() updates WalletProvider's walletName → adapter binding → triggers
+    // autoConnect via WalletProviderBase's useEffect. Calling adapter.connect()
+    // directly (the previous approach) bypasses that state propagation, so
+    // useWallet().connected stays false even after the wallet authorizes.
+    select(solflare.adapter.name);
   };
 
   const handleUseAnotherWallet = () => setVisible(true);

--- a/src/components/landing/BentoCell.test.tsx
+++ b/src/components/landing/BentoCell.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import BentoCell from './BentoCell';
+
+describe('BentoCell', () => {
+  it('renders children', () => {
+    render(
+      <BentoCell delay={1}>
+        <span>inner content</span>
+      </BentoCell>,
+    );
+    expect(screen.getByText('inner content')).toBeInTheDocument();
+  });
+
+  it('applies the className prop alongside cell base classes', () => {
+    const { container } = render(
+      <BentoCell delay={1} className="col-span-8 row-span-2">
+        x
+      </BentoCell>,
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).toContain('col-span-8');
+    expect(root.className).toContain('row-span-2');
+    expect(root.className).toContain('animate-cascade-up');
+  });
+
+  it('sets animationDelay from the delay prop (delay × 100ms)', () => {
+    const { container } = render(<BentoCell delay={3}>x</BentoCell>);
+    const root = container.firstChild as HTMLElement;
+    expect(root.style.animationDelay).toBe('300ms');
+  });
+
+  it('renders as <div> by default and accepts a different element via the `as` prop', () => {
+    const { container, rerender } = render(<BentoCell delay={1}>x</BentoCell>);
+    expect((container.firstChild as HTMLElement).tagName).toBe('DIV');
+
+    rerender(
+      <BentoCell delay={1} as="section">
+        x
+      </BentoCell>,
+    );
+    expect((container.firstChild as HTMLElement).tagName).toBe('SECTION');
+  });
+});

--- a/src/components/landing/BentoCell.tsx
+++ b/src/components/landing/BentoCell.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface Props {
+  delay: number;
+  className?: string;
+  children: React.ReactNode;
+  as?: 'div' | 'section' | 'article';
+}
+
+export default function BentoCell({
+  delay,
+  className = '',
+  children,
+  as: Component = 'div',
+}: Props) {
+  return (
+    <Component
+      style={{ animationDelay: `${delay * 100}ms` }}
+      className={[
+        'relative overflow-hidden rounded-3xl',
+        'bg-kami-cellBase border border-kami-cellBorder',
+        'p-6 lg:p-8',
+        'transition-all duration-500 ease-smooth',
+        'hover:-translate-y-[2px] hover:border-kami-amber/40',
+        'hover:shadow-[0_10px_40px_-20px_rgba(255,165,0,0.15)]',
+        'animate-cascade-up',
+        className,
+      ].join(' ')}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/src/components/landing/HeroCell.test.tsx
+++ b/src/components/landing/HeroCell.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import HeroCell from './HeroCell';
+
+const noop = () => {};
+
+describe('HeroCell', () => {
+  it('renders the env chip + headline + cursor', () => {
+    render(<HeroCell connecting={false} onConnectSolflare={noop} onUseAnotherWallet={noop} />);
+    expect(screen.getByText(/env \/ mainnet-beta/i)).toBeInTheDocument();
+    expect(screen.getByText('Type. Sign.')).toBeInTheDocument();
+    // Second headline span is "Done" + KamiCursor — its textContent is "Done▌".
+    // Use a regex anchored to the start to disambiguate from the parent h1
+    // whose textContent collapses both spans.
+    expect(screen.getByText(/^Done/)).toBeInTheDocument();
+    expect(screen.getByText('▌')).toBeInTheDocument();
+  });
+
+  it('renders the subhead with klend-sdk highlighted in mono amber', () => {
+    render(<HeroCell connecting={false} onConnectSolflare={noop} onUseAnotherWallet={noop} />);
+    const klend = screen.getByText('klend-sdk');
+    expect(klend).toBeInTheDocument();
+    expect(klend.tagName).toBe('CODE');
+    expect(klend).toHaveClass('text-kami-amber');
+  });
+
+  it('renders the mock agent input prompt', () => {
+    render(<HeroCell connecting={false} onConnectSolflare={noop} onUseAnotherWallet={noop} />);
+    expect(screen.getByText(/find best USDC yield/i)).toBeInTheDocument();
+  });
+
+  it('fires onConnectSolflare when the CTA is clicked', () => {
+    const onConnectSolflare = vi.fn();
+    render(
+      <HeroCell connecting={false} onConnectSolflare={onConnectSolflare} onUseAnotherWallet={noop} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /connect with solflare/i }));
+    expect(onConnectSolflare).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onUseAnotherWallet when the secondary link is clicked', () => {
+    const onUseAnotherWallet = vi.fn();
+    render(
+      <HeroCell connecting={false} onConnectSolflare={noop} onUseAnotherWallet={onUseAnotherWallet} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /use another solana wallet/i }));
+    expect(onUseAnotherWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "Opening Solflare…" + disables the CTA when connecting=true', () => {
+    render(<HeroCell connecting={true} onConnectSolflare={noop} onUseAnotherWallet={noop} />);
+    const cta = screen.getByRole('button', { name: /opening solflare/i });
+    expect(cta).toBeDisabled();
+  });
+});

--- a/src/components/landing/HeroCell.tsx
+++ b/src/components/landing/HeroCell.tsx
@@ -1,0 +1,62 @@
+import { Code2, Wallet } from 'lucide-react';
+import BentoCell from './BentoCell';
+import KamiCursor from './KamiCursor';
+
+interface Props {
+  connecting: boolean;
+  onConnectSolflare: () => void;
+  onUseAnotherWallet: () => void;
+}
+
+export default function HeroCell({ connecting, onConnectSolflare, onUseAnotherWallet }: Props) {
+  return (
+    <BentoCell
+      delay={1}
+      className="col-span-12 lg:col-span-8 lg:row-span-2 rounded-[2rem] flex flex-col gap-8 lg:gap-12 min-h-[24rem] lg:min-h-[28rem]"
+      as="section"
+    >
+      <div className="flex-1 flex flex-col gap-6">
+        <span className="self-start inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-kami-sepiaBg border border-kami-cellBorder font-mono text-xs text-kami-creamMuted">
+          <Code2 className="w-3.5 h-3.5" aria-hidden="true" />
+          env / mainnet-beta
+        </span>
+        <h1 className="font-display font-bold tracking-tight text-kami-cream text-5xl sm:text-6xl lg:text-7xl xl:text-[5rem] leading-[0.95]">
+          <span className="block">Type. Sign.</span>
+          <span className="block">
+            Done
+            <KamiCursor />
+          </span>
+        </h1>
+        <p className="font-sans text-kami-cream/80 text-lg lg:text-xl max-w-xl leading-relaxed">
+          Speak plain English. Kami parses your intent, calls Kamino{' '}
+          <code className="font-mono text-kami-amber not-italic">klend-sdk</code> primitives, and
+          queues a mainnet transaction. No dashboard scraping required.
+        </p>
+      </div>
+
+      <div className="border-t border-kami-cellBorder/50 pt-6 flex flex-col sm:flex-row sm:items-center gap-4 justify-between">
+        <div className="font-mono text-sm text-kami-creamMuted px-4 py-3 rounded-xl bg-kami-sepiaBg/60 border border-kami-cellBorder">
+          <span className="text-kami-amber/80">&gt; </span>find best USDC yield
+        </div>
+        <div className="flex flex-col gap-2 sm:items-end">
+          <button
+            type="button"
+            onClick={onConnectSolflare}
+            disabled={connecting}
+            className="inline-flex items-center gap-3 px-6 py-3 rounded-xl bg-kami-amber text-kami-sepiaBg font-mono uppercase tracking-wider text-sm font-bold hover:opacity-95 active:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-wait"
+          >
+            <Wallet className="w-5 h-5" aria-hidden="true" />
+            {connecting ? 'Opening Solflare…' : 'Connect with Solflare'}
+          </button>
+          <button
+            type="button"
+            onClick={onUseAnotherWallet}
+            className="text-xs text-kami-creamMuted hover:text-kami-cream transition-colors"
+          >
+            Use another Solana wallet
+          </button>
+        </div>
+      </div>
+    </BentoCell>
+  );
+}

--- a/src/components/landing/KamiCursor.test.tsx
+++ b/src/components/landing/KamiCursor.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import KamiCursor from './KamiCursor';
+
+describe('KamiCursor', () => {
+  it('renders the ▌ glyph', () => {
+    render(<KamiCursor />);
+    expect(screen.getByText('▌')).toBeInTheDocument();
+  });
+
+  it('applies the blink animation class', () => {
+    render(<KamiCursor />);
+    expect(screen.getByText('▌')).toHaveClass('animate-blink');
+  });
+
+  it('uses amber color', () => {
+    render(<KamiCursor />);
+    expect(screen.getByText('▌')).toHaveClass('text-kami-amber');
+  });
+});

--- a/src/components/landing/KamiCursor.tsx
+++ b/src/components/landing/KamiCursor.tsx
@@ -1,0 +1,7 @@
+export default function KamiCursor() {
+  return (
+    <span className="text-kami-amber animate-blink" aria-hidden="true">
+      ▌
+    </span>
+  );
+}

--- a/src/components/landing/LatestTxCell.test.tsx
+++ b/src/components/landing/LatestTxCell.test.tsx
@@ -22,7 +22,7 @@ describe('LatestTxCell', () => {
 
   it('Solscan link points to the full signature with safe target/rel', () => {
     render(<LatestTxCell delay={3} />);
-    const link = screen.getByRole('link', { name: /view on solscan/i });
+    const link = screen.getByRole('link', { name: /view solscan transaction/i });
     expect(link).toHaveAttribute('href', LATEST_TX.solscanUrl);
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');

--- a/src/components/landing/LatestTxCell.test.tsx
+++ b/src/components/landing/LatestTxCell.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import LatestTxCell from './LatestTxCell';
+import { LATEST_TX } from '../../lib/landing-content';
+
+describe('LatestTxCell', () => {
+  it('renders the log.latest_tx header + Confirmed pill', () => {
+    render(<LatestTxCell delay={3} />);
+    expect(screen.getByText('log.latest_tx')).toBeInTheDocument();
+    expect(screen.getByText('Confirmed')).toBeInTheDocument();
+  });
+
+  it('renders the truncated signature', () => {
+    render(<LatestTxCell delay={3} />);
+    expect(screen.getByText(LATEST_TX.shortSignature)).toBeInTheDocument();
+  });
+
+  it('renders the action description', () => {
+    render(<LatestTxCell delay={3} />);
+    expect(screen.getByText(LATEST_TX.action)).toBeInTheDocument();
+  });
+
+  it('Solscan link points to the full signature with safe target/rel', () => {
+    render(<LatestTxCell delay={3} />);
+    const link = screen.getByRole('link', { name: /view on solscan/i });
+    expect(link).toHaveAttribute('href', LATEST_TX.solscanUrl);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/src/components/landing/LatestTxCell.tsx
+++ b/src/components/landing/LatestTxCell.tsx
@@ -1,0 +1,49 @@
+import { ArrowLeftRight, ArrowUpRight, Check } from 'lucide-react';
+import BentoCell from './BentoCell';
+import { LATEST_TX } from '../../lib/landing-content';
+
+interface Props {
+  delay: number;
+}
+
+export default function LatestTxCell({ delay }: Props) {
+  return (
+    <BentoCell
+      delay={delay}
+      className="col-span-12 md:col-span-6 lg:col-span-4 bg-kami-cellElevated"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-kami-creamMuted">
+          <ArrowLeftRight className="w-4 h-4" aria-hidden="true" />
+          log.latest_tx
+        </div>
+        <span className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-kami-amberHaze border border-kami-amber/40 text-kami-amber font-mono text-[10px] uppercase tracking-wider">
+          <Check className="w-3 h-3" aria-hidden="true" />
+          Confirmed
+        </span>
+      </div>
+      <div className="rounded-xl border border-kami-cellBorder bg-kami-sepiaBg/40 p-4 flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-mono text-[11px] uppercase tracking-wider text-kami-creamMuted">
+            Signature
+          </span>
+          <a
+            href={LATEST_TX.solscanUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="View on Solscan"
+            className="font-mono text-sm text-kami-cream hover:text-kami-amber transition-colors inline-flex items-center gap-1"
+          >
+            {LATEST_TX.shortSignature}
+            <ArrowUpRight className="w-3.5 h-3.5" aria-hidden="true" />
+          </a>
+        </div>
+        <hr className="border-kami-cellBorder/50" />
+        <div className="flex items-center gap-3">
+          <span className="w-2 h-2 rounded-full bg-kami-amber flex-shrink-0" aria-hidden="true" />
+          <span className="font-sans text-sm text-kami-cream/90">{LATEST_TX.action}</span>
+        </div>
+      </div>
+    </BentoCell>
+  );
+}

--- a/src/components/landing/LatestTxCell.tsx
+++ b/src/components/landing/LatestTxCell.tsx
@@ -12,6 +12,7 @@ export default function LatestTxCell({ delay }: Props) {
       delay={delay}
       className="col-span-12 md:col-span-6 lg:col-span-4 bg-kami-cellElevated"
     >
+      {/* bg-kami-cellElevated overrides BentoCell's default bg-kami-cellBase via Tailwind class-emit order. */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-kami-creamMuted">
           <ArrowLeftRight className="w-4 h-4" aria-hidden="true" />
@@ -31,7 +32,7 @@ export default function LatestTxCell({ delay }: Props) {
             href={LATEST_TX.solscanUrl}
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="View on Solscan"
+            aria-label={`View Solscan transaction ${LATEST_TX.shortSignature}`}
             className="font-mono text-sm text-kami-cream hover:text-kami-amber transition-colors inline-flex items-center gap-1"
           >
             {LATEST_TX.shortSignature}

--- a/src/components/landing/PipelineCell.test.tsx
+++ b/src/components/landing/PipelineCell.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import PipelineCell from './PipelineCell';
+
+describe('PipelineCell', () => {
+  it('renders all 3 step labels', () => {
+    render(<PipelineCell delay={8} />);
+    expect(screen.getByText('INTENT')).toBeInTheDocument();
+    expect(screen.getByText('SIGNATURE')).toBeInTheDocument();
+    expect(screen.getByText('EXECUTION')).toBeInTheDocument();
+  });
+
+  it('renders all 3 step indices in [N/3] form', () => {
+    render(<PipelineCell delay={8} />);
+    expect(screen.getByText('[1/3]')).toBeInTheDocument();
+    expect(screen.getByText('[2/3]')).toBeInTheDocument();
+    expect(screen.getByText('[3/3]')).toBeInTheDocument();
+  });
+
+  it('renders 3 lucide svg icons (one per step)', () => {
+    const { container } = render(<PipelineCell delay={8} />);
+    expect(container.querySelectorAll('svg')).toHaveLength(3);
+  });
+});

--- a/src/components/landing/PipelineCell.tsx
+++ b/src/components/landing/PipelineCell.tsx
@@ -1,0 +1,48 @@
+import { Terminal, PenLine, CheckCircle2, type LucideIcon } from 'lucide-react';
+import BentoCell from './BentoCell';
+import { PIPELINE_STEPS, type PipelineIconKey } from '../../lib/landing-content';
+
+const ICON_MAP: Record<PipelineIconKey, LucideIcon> = {
+  intent: Terminal,
+  signature: PenLine,
+  execution: CheckCircle2,
+};
+
+interface Props {
+  delay: number;
+}
+
+export default function PipelineCell({ delay }: Props) {
+  return (
+    <BentoCell
+      delay={delay}
+      className="col-span-12 border-dashed lg:p-10"
+    >
+      <div className="relative flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div
+          className="hidden lg:block absolute left-0 right-0 top-1/2 h-px bg-kami-cellBorder"
+          aria-hidden="true"
+        />
+        {PIPELINE_STEPS.map((step) => {
+          const Icon = ICON_MAP[step.iconKey];
+          return (
+            <div
+              key={step.label}
+              className="relative flex items-center gap-4 px-6 py-4 rounded-xl bg-kami-sepiaBg/60 border border-kami-cellBorder hover:border-kami-amber/40 transition-colors group"
+            >
+              <Icon className="w-6 h-6 text-kami-amber" aria-hidden="true" />
+              <div className="flex flex-col gap-0.5">
+                <span className="font-mono text-[10px] text-kami-creamMuted group-hover:text-kami-amber transition-colors">
+                  [{step.index}]
+                </span>
+                <span className="font-mono text-sm font-bold uppercase tracking-wider text-kami-cream">
+                  {step.label}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </BentoCell>
+  );
+}

--- a/src/components/landing/SponsorStrip.test.tsx
+++ b/src/components/landing/SponsorStrip.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import SponsorStrip from './SponsorStrip';
+import { SPONSORS } from '../../lib/landing-content';
+
+describe('SponsorStrip', () => {
+  it('renders all 5 sponsor wordmarks', () => {
+    render(<SponsorStrip />);
+    SPONSORS.forEach((s) => {
+      expect(screen.getByText(s)).toBeInTheDocument();
+    });
+  });
+
+  it('renders sponsors in the canonical order', () => {
+    const { container } = render(<SponsorStrip />);
+    const text = container.textContent ?? '';
+    const indices = SPONSORS.map((s) => text.indexOf(s));
+    const sorted = [...indices].sort((a, b) => a - b);
+    expect(indices).toEqual(sorted);
+  });
+});

--- a/src/components/landing/SponsorStrip.tsx
+++ b/src/components/landing/SponsorStrip.tsx
@@ -1,0 +1,24 @@
+import { Fragment } from 'react';
+import { SPONSORS } from '../../lib/landing-content';
+
+export default function SponsorStrip() {
+  return (
+    <div
+      className="col-span-12 py-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-3 opacity-50 grayscale hover:opacity-100 hover:grayscale-0 transition-all duration-500 ease-smooth"
+      aria-label="Sponsors"
+    >
+      {SPONSORS.map((name, i) => (
+        <Fragment key={name}>
+          <span className="font-display font-bold uppercase tracking-widest text-sm text-kami-cream">
+            {name}
+          </span>
+          {i < SPONSORS.length - 1 ? (
+            <span aria-hidden="true" className="text-kami-amber/40">
+              ·
+            </span>
+          ) : null}
+        </Fragment>
+      ))}
+    </div>
+  );
+}

--- a/src/components/landing/SysMetricsCell.test.tsx
+++ b/src/components/landing/SysMetricsCell.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import SysMetricsCell from './SysMetricsCell';
+import { LANDING_STATS } from '../../lib/landing-content';
+
+describe('SysMetricsCell', () => {
+  it('renders the sys.metrics header', () => {
+    render(<SysMetricsCell delay={2} />);
+    expect(screen.getByText('sys.metrics')).toBeInTheDocument();
+  });
+
+  it('renders all 4 metric keys + values from LANDING_STATS', () => {
+    render(<SysMetricsCell delay={2} />);
+    LANDING_STATS.forEach((stat) => {
+      expect(screen.getByText(stat.key)).toBeInTheDocument();
+      expect(screen.getByText(stat.value)).toBeInTheDocument();
+    });
+  });
+
+  it('renders the highlighted value (sys.tools_loaded) in amber', () => {
+    render(<SysMetricsCell delay={2} />);
+    const highlighted = LANDING_STATS.find((s) => s.highlight)!;
+    expect(screen.getByText(highlighted.value)).toHaveClass('text-kami-amber');
+  });
+
+  it('renders non-highlighted values in cream', () => {
+    render(<SysMetricsCell delay={2} />);
+    const nonHighlighted = LANDING_STATS.find((s) => !s.highlight)!;
+    expect(screen.getByText(nonHighlighted.value)).toHaveClass('text-kami-cream');
+  });
+});

--- a/src/components/landing/SysMetricsCell.tsx
+++ b/src/components/landing/SysMetricsCell.tsx
@@ -1,0 +1,39 @@
+import { Cpu } from 'lucide-react';
+import BentoCell from './BentoCell';
+import { LANDING_STATS } from '../../lib/landing-content';
+
+interface Props {
+  delay: number;
+}
+
+export default function SysMetricsCell({ delay }: Props) {
+  return (
+    <BentoCell delay={delay} className="col-span-12 md:col-span-6 lg:col-span-4">
+      <div className="flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-kami-creamMuted mb-6">
+        <Cpu className="w-4 h-4" aria-hidden="true" />
+        sys.metrics
+      </div>
+      <ul className="flex flex-col">
+        {LANDING_STATS.map((stat, i) => (
+          <li
+            key={stat.key}
+            className={[
+              'flex justify-between items-baseline py-3 font-mono text-sm group',
+              i < LANDING_STATS.length - 1 ? 'border-b border-kami-cellBorder/50' : '',
+            ].join(' ')}
+          >
+            <span className="text-kami-creamMuted">{stat.key}</span>
+            <span
+              className={[
+                'transition-transform duration-200 ease-smooth group-hover:translate-x-[1px]',
+                stat.highlight ? 'text-kami-amber font-bold' : 'text-kami-cream',
+              ].join(' ')}
+            >
+              {stat.value}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </BentoCell>
+  );
+}

--- a/src/components/landing/ToolCell.test.tsx
+++ b/src/components/landing/ToolCell.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ToolCell from './ToolCell';
+import { TOOL_CELLS } from '../../lib/landing-content';
+
+describe('ToolCell', () => {
+  it('renders name + description + hint', () => {
+    const tool = TOOL_CELLS[0]; // tool/findYield
+    render(<ToolCell tool={tool} delay={4} />);
+    expect(screen.getByText(tool.name)).toBeInTheDocument();
+    expect(screen.getByText(tool.description)).toBeInTheDocument();
+    expect(screen.getByText(tool.hint)).toBeInTheDocument();
+  });
+
+  it('renders an icon (lucide svg)', () => {
+    const { container } = render(<ToolCell tool={TOOL_CELLS[0]} delay={4} />);
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders all 4 TOOL_CELLS by name when mapped', () => {
+    render(
+      <>
+        {TOOL_CELLS.map((t, i) => (
+          <ToolCell key={t.name} tool={t} delay={4 + i} />
+        ))}
+      </>,
+    );
+    expect(screen.getByText('tool/findYield')).toBeInTheDocument();
+    expect(screen.getByText('tool/getPortfolio')).toBeInTheDocument();
+    expect(screen.getByText('tool/simulateHealth')).toBeInTheDocument();
+    expect(screen.getByText('tool/buildSign')).toBeInTheDocument();
+  });
+});

--- a/src/components/landing/ToolCell.tsx
+++ b/src/components/landing/ToolCell.tsx
@@ -1,0 +1,42 @@
+import {
+  FolderOpen,
+  Wallet,
+  ShieldCheck,
+  PenLine,
+  type LucideIcon,
+} from 'lucide-react';
+import BentoCell from './BentoCell';
+import type { ToolCellData, ToolIconKey } from '../../lib/landing-content';
+
+const ICON_MAP: Record<ToolIconKey, LucideIcon> = {
+  findYield: FolderOpen,
+  getPortfolio: Wallet,
+  simulateHealth: ShieldCheck,
+  buildSign: PenLine,
+};
+
+interface Props {
+  tool: ToolCellData;
+  delay: number;
+}
+
+export default function ToolCell({ tool, delay }: Props) {
+  const Icon = ICON_MAP[tool.iconKey];
+  return (
+    <BentoCell
+      delay={delay}
+      className="col-span-12 sm:col-span-6 lg:col-span-3 flex flex-col gap-3 group"
+    >
+      <div className="flex items-center gap-2 font-mono text-sm text-kami-amber">
+        <Icon className="w-4 h-4" aria-hidden="true" />
+        {tool.name}
+      </div>
+      <p className="font-sans text-sm text-kami-cream/80 leading-relaxed flex-1">
+        {tool.description}
+      </p>
+      <div className="font-mono text-[11px] text-kami-creamMuted px-3 py-2 rounded-lg border border-kami-cellBorder bg-kami-sepiaBg/40 group-hover:border-kami-amber/40 transition-colors">
+        {tool.hint}
+      </div>
+    </BentoCell>
+  );
+}

--- a/src/lib/landing-content.test.ts
+++ b/src/lib/landing-content.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LANDING_STATS,
+  LATEST_TX,
+  SPONSORS,
+  TOOL_CELLS,
+  PIPELINE_STEPS,
+} from './landing-content';
+
+describe('landing-content', () => {
+  it('LANDING_STATS has 4 entries with key/value/highlight shape', () => {
+    expect(LANDING_STATS).toHaveLength(4);
+    LANDING_STATS.forEach((s) => {
+      expect(typeof s.key).toBe('string');
+      expect(typeof s.value).toBe('string');
+      expect(typeof s.highlight).toBe('boolean');
+    });
+    expect(LANDING_STATS[0].key).toBe('sys.tools_loaded');
+    expect(LANDING_STATS[0].highlight).toBe(true);
+  });
+
+  it('LATEST_TX has the Day-6 mainnet signature + Solscan URL', () => {
+    expect(LATEST_TX.signature).toMatch(/^[1-9A-HJ-NP-Za-km-z]{86,90}$/);
+    expect(LATEST_TX.solscanUrl).toContain(LATEST_TX.signature);
+    expect(LATEST_TX.solscanUrl.startsWith('https://solscan.io/tx/')).toBe(true);
+    expect(LATEST_TX.action).toBe('5 USDC supplied to Kamino');
+  });
+
+  it('SPONSORS includes the 5 bounty-acknowledged sponsors in order', () => {
+    expect(SPONSORS).toEqual(['Eitherway', 'Kamino', 'Solflare', 'Helius', 'Vercel']);
+  });
+
+  it('TOOL_CELLS has 4 entries with name/description/hint/iconKey shape', () => {
+    expect(TOOL_CELLS).toHaveLength(4);
+    const names = TOOL_CELLS.map((t) => t.name);
+    expect(names).toEqual([
+      'tool/findYield',
+      'tool/getPortfolio',
+      'tool/simulateHealth',
+      'tool/buildSign',
+    ]);
+    TOOL_CELLS.forEach((t) => {
+      expect(typeof t.description).toBe('string');
+      expect(t.hint.startsWith('→ ')).toBe(true);
+      expect(typeof t.iconKey).toBe('string');
+    });
+  });
+
+  it('PIPELINE_STEPS has 3 entries with index/label/iconKey shape', () => {
+    expect(PIPELINE_STEPS).toHaveLength(3);
+    const labels = PIPELINE_STEPS.map((p) => p.label);
+    expect(labels).toEqual(['INTENT', 'SIGNATURE', 'EXECUTION']);
+    PIPELINE_STEPS.forEach((p, i) => {
+      expect(p.index).toBe(`${i + 1}/3`);
+    });
+  });
+});

--- a/src/lib/landing-content.ts
+++ b/src/lib/landing-content.ts
@@ -1,0 +1,93 @@
+// Hardcoded data for the bento landing. Centralized so future
+// updates (test count drifts, new sponsors) touch one place.
+
+export interface LandingStat {
+  key: string;
+  value: string;
+  highlight: boolean;
+}
+
+export const LANDING_STATS: ReadonlyArray<LandingStat> = [
+  { key: 'sys.tools_loaded', value: '7 active', highlight: true },
+  { key: 'ci.tests_passing', value: '186 suite', highlight: false },
+  { key: 'net.roundtrips', value: '3 mainnet', highlight: false },
+  { key: 'sys.genesis', value: '2026-04-19', highlight: false },
+];
+
+export interface LatestTx {
+  signature: string;
+  shortSignature: string;
+  solscanUrl: string;
+  action: string;
+}
+
+const TX_SIG = '5XKeETjGfmj9jEWUNCKcf8u49bY4hEzX2a7JcB4nPxQCBbmZ7ipoNrgTXQMJWXHvKw7Bsera9xxYygLVxLUpUvZE';
+
+export const LATEST_TX: LatestTx = {
+  signature: TX_SIG,
+  shortSignature: `${TX_SIG.slice(0, 10)}…${TX_SIG.slice(-5)}`,
+  solscanUrl: `https://solscan.io/tx/${TX_SIG}`,
+  action: '5 USDC supplied to Kamino',
+};
+
+export const SPONSORS: ReadonlyArray<string> = [
+  'Eitherway',
+  'Kamino',
+  'Solflare',
+  'Helius',
+  'Vercel',
+];
+
+export type ToolIconKey =
+  | 'findYield'
+  | 'getPortfolio'
+  | 'simulateHealth'
+  | 'buildSign';
+
+export interface ToolCellData {
+  name: string;
+  description: string;
+  hint: string;
+  iconKey: ToolIconKey;
+}
+
+export const TOOL_CELLS: ReadonlyArray<ToolCellData> = [
+  {
+    name: 'tool/findYield',
+    description: 'Scans Kamino reserves for highest supply / borrow APY.',
+    hint: '→ KaminoMarket.reserves',
+    iconKey: 'findYield',
+  },
+  {
+    name: 'tool/getPortfolio',
+    description: "Fetches connected wallet's positions, debt, health factor.",
+    hint: '→ KaminoMarket.getObligationByAddress',
+    iconKey: 'getPortfolio',
+  },
+  {
+    name: 'tool/simulateHealth',
+    description: 'Projects post-action health factor before signing.',
+    hint: '→ Obligation.simulateBorrowAndWithdrawAction',
+    iconKey: 'simulateHealth',
+  },
+  {
+    name: 'tool/buildSign',
+    description: 'Builds + signs deposit / borrow / withdraw / repay v0 transactions.',
+    hint: '→ KaminoAction.build*Txns',
+    iconKey: 'buildSign',
+  },
+];
+
+export type PipelineIconKey = 'intent' | 'signature' | 'execution';
+
+export interface PipelineStep {
+  index: string;
+  label: string;
+  iconKey: PipelineIconKey;
+}
+
+export const PIPELINE_STEPS: ReadonlyArray<PipelineStep> = [
+  { index: '1/3', label: 'INTENT', iconKey: 'intent' },
+  { index: '2/3', label: 'SIGNATURE', iconKey: 'signature' },
+  { index: '3/3', label: 'EXECUTION', iconKey: 'execution' },
+];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,11 +18,48 @@ export default {
           success: '#10b981',
           warning: '#f59e0b',
           danger: '#ef4444',
+
+          // Bento landing palette (Sprint 5 / Day 18). The chat shell
+          // still uses kami.bg/surface/accent above; restyling that is
+          // a follow-up spec.
+          sepiaBg: '#1a1410',
+          cellBase: '#221a14',
+          cellElevated: '#2a2117',
+          cellBorder: 'rgba(245, 230, 211, 0.12)',
+          cream: '#F5E6D3',
+          creamMuted: 'rgba(245, 230, 211, 0.6)',
+          amber: '#FFA500',
+          amberGlow: 'rgba(255, 165, 0, 0.15)',
+          amberHaze: 'rgba(255, 165, 0, 0.05)',
         },
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
         mono: ['JetBrains Mono', 'Fira Code', 'monospace'],
+        display: ['Unbounded', 'sans-serif'],
+      },
+      transitionTimingFunction: {
+        spring: 'cubic-bezier(0.175, 0.885, 0.32, 1.275)',
+        smooth: 'cubic-bezier(0.4, 0, 0.2, 1)',
+      },
+      keyframes: {
+        'cascade-up': {
+          '0%': { opacity: '0', transform: 'translateY(20px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        blink: {
+          '0%, 50%': { opacity: '1' },
+          '50.01%, 100%': { opacity: '0' },
+        },
+        'pulse-dot': {
+          '0%': { boxShadow: '0 0 0 0 rgba(255, 165, 0, 0.4)' },
+          '100%': { boxShadow: '0 0 0 8px rgba(255, 165, 0, 0)' },
+        },
+      },
+      animation: {
+        'cascade-up': 'cascade-up 800ms cubic-bezier(0.175, 0.885, 0.32, 1.275) backwards',
+        blink: 'blink 1s step-end infinite',
+        'pulse-dot': 'pulse-dot 2s ease-out infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary

Replaces the minimal `EmptyState.tsx` (gradient K logo + 4 feature cards + CTA) with a full **bento-grid pre-connect landing** in an amber-on-sepia palette. 9 cells across a 12-col grid: hero (8×2) + sys.metrics (4) + log.latest_tx (4) + 4 tool cells (3 each) + pipeline (12) + sponsor strip (12).

- **Spec:** [`docs/superpowers/specs/2026-04-28-kami-landing-bento-amber-design.md`](docs/superpowers/specs/2026-04-28-kami-landing-bento-amber-design.md) (committed `de626e3`)
- **Plan:** [`docs/superpowers/plans/2026-04-28-kami-landing-bento-amber-implementation.md`](docs/superpowers/plans/2026-04-28-kami-landing-bento-amber-implementation.md) (committed `defcc9c`)

### What's new

- **8 new components** under `src/components/landing/`: `KamiCursor` + `BentoCell` (primitives), `HeroCell` (with Solflare CTA), `SysMetricsCell` (4 stats), `LatestTxCell` (Day-6 mainnet proof-of-life), `ToolCell` (×4 — findYield/getPortfolio/simulateHealth/buildSign), `PipelineCell` (3-step flow), `SponsorStrip` (Eitherway · Kamino · Solflare · Helius · Vercel).
- **9 new Tailwind tokens** under `kami.*`: `sepiaBg`, `cellBase`, `cellElevated`, `cellBorder`, `cream`, `creamMuted`, `amber`, `amberGlow`, `amberHaze`. The 12 existing `kami.*` dark-blue tokens preserved unchanged for the chat shell (restyling those is a follow-up spec).
- **Unbounded display font** added (700/800), JetBrains Mono bumped to weight 700.
- **3 keyframes** (`cascade-up`, `blink`, `pulse-dot`) + 2 timing functions (`spring`, `smooth`).
- **Centralized data** in `src/lib/landing-content.ts` — 4 stats / Day-6 mainnet tx / 5 sponsors / 4 tool cells / 3 pipeline steps.

### Behavior changes

- **Tool cells are non-clickable** info displays per spec §5.4 (was: 4 clickable feature cards firing sample queries via `onSend`). Visitors who want to type queries do so via `ChatInput` post-connect. The `onSend` prop is removed from `EmptyState` and from the `<EmptyState>` call site in `ChatPanel.tsx`.
- **Existing render condition preserved**: bento renders when `conversation.messages.length === 0` (both pre-connect AND post-connect-empty). Spec §6.1 said "connected===false" but that's loose wording — the existing condition is safer and matches what the chat shell expects.
- **Chat shell unchanged**: `ChatPanel` / `Sidebar` / `ChatInput` / `ChatMessage` / `SignTransactionCard` / `ConnectWalletButton` keep their current `kami-accent` purple styling. A follow-up spec will restyle the chat surfaces to amber so the post-connect experience coheres with the landing.

### Architecture

Composer pattern: `EmptyState.tsx` owns the wallet hooks (`useWallet` + `useWalletModal`) and the connect/fallback handlers, and passes plain props to `HeroCell` (`connecting`, `onConnectSolflare`, `onUseAnotherWallet`). All 7 cell components are pure — props in, JSX out, no hooks. `BentoCell` is a shared wrapper handling rounded-corner + cell base bg + hover lift + cascade-up entrance. Animation choreography (`delay × 100ms`) sequenced at the EmptyState grid level: hero=1, sys.metrics=2, latest_tx=3, tool cells=4-7, pipeline=8 (sponsor strip is not a BentoCell — no animation, no border, just a subdued strip).

## Tests

- **186 → 222 (+36)** across **9 new test files + 1 refreshed**: +5 landing-content, +3 KamiCursor, +4 BentoCell, +6 HeroCell, +4 SysMetricsCell, +4 LatestTxCell, +3 ToolCell, +3 PipelineCell, +2 SponsorStrip, +2 net EmptyState refresh (5 old → 7 new).
- All 3 typechecks green: `pnpm exec tsc --noEmit` (client) + `pnpm exec tsc -p server/tsconfig.json --noEmit` (server) + `pnpm exec tsc -b` (project mode).
- `pnpm build` succeeds. Main bundle: 629.9 kB / 193.87 kB gzipped (+13.9 kB over the prior ~616 kB baseline — 8 new components add roughly 1.7 kB gzipped each).

## Visual QA

Verified locally at 1440×900 desktop in Chrome via Chrome MCP — bento renders all 9 cells correctly. Hero headline `Type. Sign. Done▌` with the amber blink cursor visible. Stats highlight `7 active` in amber. Day-6 mainnet signature shows `5XKeETjGfm…pUvZE` with the Solscan ↗ link. 4 tool cells in a row across 12 cols. Pipeline strip with the 3-step flow + hairline track-line behind. Sponsor strip in subdued grayscale (the modesty pattern — hover reveals full color). No console errors.

Mobile (375px) + tablet (768px) viewport QA deferred to the Vercel preview deploy; Chrome MCP's `resize_window` didn't reliably reflect viewport changes in screenshots locally.

## Test plan

- [ ] Vercel preview deploy renders correctly at desktop (≥ 1280px) — 8-col hero × 2-row + side cells stacked + 4 tool cells in one row + pipeline + sponsor strip.
- [ ] Vercel preview at tablet (768px) — hero collapses to 12-col, side cells side-by-side, tool cells 2×2.
- [ ] Vercel preview at mobile (375px) — single-column stack, no horizontal scroll, pipeline steps stack vertically.
- [ ] CTA flow: Connect with Solflare → Solflare popup → connected → chat shell takes over.
- [ ] Use another Solana wallet → wallet adapter modal opens.
- [ ] Cascade entrance animation runs once on first load; cells settle within ~1.6s.
- [ ] Lighthouse perf ≥ 90.
- [ ] Smoke: `https://kami.rectorspace.com/` renders the bento landing for a logged-out / fresh-localStorage visitor.

## Follow-ups (post-merge)

Cluster reviewers (opus) flagged 17 minors across the 7 tasks — all defer-OK. The 3 worth tracking as separate GitHub issues post-merge:

- **a11y**: `SponsorStrip` `aria-label="Sponsors"` is on a bare `<div>` — promote to `<aside>` or add `role="region"` so screen readers announce the landmark.
- **a11y**: `HeroCell` CTA loading state could announce via `aria-busy={connecting}` so screen-reader users know the connect flow is in progress.
- **arch**: `BentoCell` hardcodes `bg-kami-cellBase` in its base classes; `LatestTxCell` overrides it with `bg-kami-cellElevated` via className. Override works empirically (verified in compiled CSS) but relies on alphabetical token-emit ordering — refactor to accept a `bg?` prop OR drop the default to make the override explicit.

## Commits

10 commits on this branch:
- `de626e3` docs(spec): kami landing bento amber design
- `a1d097d` Task 1 — theme + Unbounded + landing-content
- `dd8f015` Task 2 — KamiCursor + BentoCell primitives
- `ec9457f` Task 3 — HeroCell with Solflare CTA
- `e10c463` Task 4 — SysMetricsCell + LatestTxCell
- `d32a7ba` Task 4 fix — Solscan aria-label parity + cellElevated cascade comment
- `fb69800` Task 5 — ToolCell
- `3d83373` Task 6 — PipelineCell + SponsorStrip
- `dfb54d4` Task 7 — wire EmptyState + drop onSend prop
- `defcc9c` docs(plan): the implementation plan itself

Each task shipped via subagent-driven-development with two-stage review (spec compliance + code quality) per task. 9 of 10 commits are `feat(landing):`/`fix(landing):` — clean conventional history.