### PR TITLE
chore(landing): update ci.tests_passing stat 186 → 270

### DIFF
--- a/src/lib/landing-content.ts
+++ b/src/lib/landing-content.ts
@@ -9,7 +9,7 @@ export interface LandingStat {
 
 export const LANDING_STATS: ReadonlyArray<LandingStat> = [
   { key: 'sys.tools_loaded', value: '7 active', highlight: true },
-  { key: 'ci.tests_passing', value: '186 suite', highlight: false },
+  { key: 'ci.tests_passing', value: '270 suite', highlight: false },
   { key: 'net.roundtrips', value: '3 mainnet', highlight: false },
   { key: 'sys.genesis', value: '2026-04-19', highlight: false },
 ];


### PR DESCRIPTION
## Summary
- Bumps the bento landing's SYS.METRICS `ci.tests_passing` from `186 suite` to `270 suite` to reflect current main HEAD post-PR #49 merge.
- Single-line content edit in `src/lib/landing-content.ts`. No behavior change.

## Test plan
- [ ] All 270 tests still pass on CI
- [ ] Vercel preview shows `270 suite` in the SYS.METRICS card