### PR TITLE
fix(chat): listen for client disconnect on res, not req

### DIFF
--- a/api/chat.test.ts
+++ b/api/chat.test.ts
@@ -369,7 +369,12 @@ describe('api/chat handler', () => {
     expect(chatMocks.lastSignal?.aborted).toBe(false);
   });
 
-  it('aborts the AbortSignal when req emits close before res.writableEnded', async () => {
+  it('registers a close listener on res (not req) for abort detection', async () => {
+    // We listen on res, not req — Vercel's serverless runtime fires
+    // req.on('close') after readBody() drains the body, which would prematurely
+    // kill the LLM stream. res.on('close') only fires when the response is
+    // forcibly destroyed (real client disconnect mid-stream). This test pins
+    // the listener registration contract so the bug can't silently come back.
     let releaseStream: () => void = () => {};
     chatMocks.streamGate = new Promise<void>((r) => {
       releaseStream = r;
@@ -388,26 +393,45 @@ describe('api/chat handler', () => {
     await new Promise((r) => setImmediate(r));
     expect(chatMocks.lastSignal?.aborted).toBe(false);
 
-    (req as unknown as Readable).emit('close');
+    // res must have at least one close listener (from our handler). Calling
+    // it triggers controller.abort() because writableEnded is still false.
+    const resListeners = cap.res.listeners('close');
+    expect(resListeners.length).toBeGreaterThan(0);
+    (resListeners[0] as () => void)();
     expect(chatMocks.lastSignal?.aborted).toBe(true);
 
     releaseStream();
-    await handlerDone;
+    // The pipe may or may not unwind cleanly after mid-stream abort — both
+    // resolve and reject are acceptable since the abort assertion above is
+    // the actual contract under test.
+    await handlerDone.catch(() => {});
   });
 
-  it('does not abort the AbortSignal when req emits close after res.writableEnded', async () => {
+  it('does not abort the AbortSignal when req emits close (Vercel runtime quirk regression guard)', async () => {
+    // req.on('close') used to fire prematurely in Vercel, killing the stream
+    // before any tokens. Listener was moved to res. Verify req close has no
+    // effect on the abort signal.
+    let releaseStream: () => void = () => {};
+    chatMocks.streamGate = new Promise<void>((r) => {
+      releaseStream = r;
+    });
     ratelimitMocks.next = {
       ok: true,
       limit: 30,
       remaining: 29,
       reset: Date.now() + 60_000,
     };
+
     const req = makeReq({ body: validBody() });
     const cap = makeRes();
-    await handler(req, cap.res);
+    const handlerDone = handler(req, cap.res);
 
+    await new Promise((r) => setImmediate(r));
     (req as unknown as Readable).emit('close');
     expect(chatMocks.lastSignal?.aborted).toBe(false);
+
+    releaseStream();
+    await handlerDone;
   });
 
   it('returns 429 with X-RateLimit-Limit: 0 when identify() yields an empty string', async () => {

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -119,7 +119,11 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
   });
 
   const controller = new AbortController();
-  req.on('close', () => {
+  // Listen on res, not req: in Vercel's serverless runtime req.on('close') fires
+  // after readBody() drains the body, which kills the LLM stream before any
+  // tokens are produced. res.on('close') only fires when the response is
+  // forcibly destroyed before res.end() — i.e., the client genuinely disconnected.
+  res.on('close', () => {
     if (!res.writableEnded) {
       controller.abort();
       logger.info({ wallet: walletAddress ?? null }, 'chat:aborted');


### PR DESCRIPTION
## Summary
Production /api/chat returns `data: [DONE]` with zero tokens — Vercel's req.on('close') fires after readBody drains, killing the LLM stream prematurely. Switch disconnect detection to res.on('close').

## Root cause
Vercel runtime quirk: req's 'close' event fires after the request body is fully consumed by readBody, even though response is still streaming. Local Fastify dev was unaffected.

## Verification
- Local curl POST /api/chat → streams text deltas correctly
- 270 tests pass (refactored 2 abort tests; added regression guard)
- Direct OpenRouter call with same key works

## Test plan
- [ ] Production /api/chat returns text deltas after deploy
- [ ] Chat shell renders assistant content end-to-end
- [ ] Regression test 'does not abort when req emits close' passes