### PR TITLE
fix(chat): persist tx lifecycle so TxStatusCard hydrates on reload

### DIFF
--- a/docs/superpowers/plans/2026-05-01-txstatuscard-reload-hydration-implementation.md
+++ b/docs/superpowers/plans/2026-05-01-txstatuscard-reload-hydration-implementation.md
@@ -1,0 +1,1042 @@
+# TxStatusCard Reload Hydration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist transaction lifecycle (`submitted → confirmed | failed`) so TxStatusCard hydrates correctly across page reload, conversation switch, and component remount, and resume `pollSignatureStatus` for any signed-but-not-yet-confirmed transaction. Closes the duplicate-sign window on reload.
+
+**Architecture:** Three surfaces: `useChat` exports new `updatePendingTransaction(messageId, patch)` method; `TxStatusCard` accepts new optional `onStatusChange` prop and adds a mount-only `useEffect` that resumes polling when persisted state is `'submitted'` with a signature; `MessageBubble` + `App.tsx` wire the callback chain through. Zero schema changes — `PendingTransaction.status` enum already includes `'submitted' | 'confirmed' | 'failed'` and `signature` is already optional in `src/types.ts`.
+
+**Tech Stack:** React 18 + TypeScript + Vitest 4 (`vi.hoisted` + `vi.mock` for shared mocks) + happy-dom + `@testing-library/react` (`renderHook`, `render`, `act`, `waitFor`).
+
+**Spec:** `docs/superpowers/specs/2026-05-01-txstatuscard-reload-hydration-design.md`
+
+---
+
+## Pre-flight (run once before Task 1)
+
+Verify the branch is `fix/txstatuscard-reload-hydration` and the spec commit is at HEAD:
+
+```bash
+git branch --show-current   # expect: fix/txstatuscard-reload-hydration
+git log --oneline -3        # expect: top commit is "docs(spec): clarify resume-poll useEffect..."
+pnpm test:run               # baseline: 270 passing across 39 files
+```
+
+Expected baseline: **270 tests passing**. Plan target after all 4 tasks: **284 tests passing** (+14).
+
+---
+
+### Task 1: Add `updatePendingTransaction` to useChat
+
+**Files:**
+- Modify: `src/hooks/useChat.ts` (add method, return from hook)
+- Modify: `src/hooks/useChat.test.ts` (append new describe block with 5 tests)
+
+**Why first:** This is a pure-function-on-state utility with zero UI dependencies. Land it in isolation to validate the persistence contract before any component wiring.
+
+- [ ] **Step 1.1: Write 5 failing tests for `updatePendingTransaction`**
+
+Append the following describe block to `src/hooks/useChat.test.ts` (after the last existing describe, before EOF):
+
+```ts
+describe('useChat updatePendingTransaction', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function seedConversationsWithPendingTx() {
+    const conv = {
+      id: 'c1',
+      title: 'deposit flow',
+      messages: [
+        { id: 'u1', role: 'user' as const, content: 'deposit 5 USDC', timestamp: 1 },
+        {
+          id: 'a1',
+          role: 'assistant' as const,
+          content: 'tx ready',
+          timestamp: 2,
+          pendingTransaction: {
+            action: 'deposit' as const,
+            protocol: 'Kamino' as const,
+            symbol: 'USDC',
+            amount: 5,
+            reserveAddress: 'D6q6wuQSrifJKZYpR1M8R4YawnLDtDsMmWM1NbBmgJ59',
+            mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            summary: 'Deposit 5 USDC',
+            base64Txn: 'AQAAAA==',
+            blockhash: 'bh-1',
+            lastValidBlockHeight: '300000000',
+            status: 'pending' as const,
+          },
+        },
+      ],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    localStorage.setItem('kami_conversations', JSON.stringify([conv]));
+    localStorage.setItem('kami_active_conversation', 'c1');
+  }
+
+  it('patches the target message pendingTransaction with shallow merge', () => {
+    seedConversationsWithPendingTx();
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.updatePendingTransaction('a1', {
+        status: 'submitted',
+        signature: 'sig-abc',
+      });
+    });
+
+    const msg = result.current.activeConversation.messages.find((m) => m.id === 'a1');
+    expect(msg?.pendingTransaction?.status).toBe('submitted');
+    expect(msg?.pendingTransaction?.signature).toBe('sig-abc');
+    // Untouched fields preserved:
+    expect(msg?.pendingTransaction?.base64Txn).toBe('AQAAAA==');
+    expect(msg?.pendingTransaction?.amount).toBe(5);
+  });
+
+  it('persists the update to localStorage via saveConversations', () => {
+    seedConversationsWithPendingTx();
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.updatePendingTransaction('a1', { status: 'confirmed' });
+    });
+
+    const raw = localStorage.getItem('kami_conversations');
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!);
+    const persistedMsg = parsed[0].messages.find((m: { id: string }) => m.id === 'a1');
+    expect(persistedMsg.pendingTransaction.status).toBe('confirmed');
+  });
+
+  it('is a no-op when messageId is not found', () => {
+    seedConversationsWithPendingTx();
+    const { result } = renderHook(() => useChat());
+    const before = JSON.stringify(result.current.conversations);
+
+    act(() => {
+      result.current.updatePendingTransaction('non-existent-id', {
+        status: 'confirmed',
+      });
+    });
+
+    const after = JSON.stringify(result.current.conversations);
+    expect(after).toBe(before);
+  });
+
+  it('is a no-op when the message exists but has no pendingTransaction', () => {
+    const conv = {
+      id: 'c1',
+      title: 'plain chat',
+      messages: [
+        { id: 'u1', role: 'user' as const, content: 'hi', timestamp: 1 },
+        { id: 'a1', role: 'assistant' as const, content: 'hello', timestamp: 2 },
+      ],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    localStorage.setItem('kami_conversations', JSON.stringify([conv]));
+    localStorage.setItem('kami_active_conversation', 'c1');
+
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.updatePendingTransaction('a1', { status: 'confirmed' });
+    });
+
+    const msg = result.current.activeConversation.messages.find((m) => m.id === 'a1');
+    expect(msg?.pendingTransaction).toBeUndefined();
+  });
+
+  it('does not mutate other messages when patching one', () => {
+    const conv = {
+      id: 'c1',
+      title: 'two txs',
+      messages: [
+        {
+          id: 'a1',
+          role: 'assistant' as const,
+          content: 'tx1',
+          timestamp: 1,
+          pendingTransaction: {
+            action: 'deposit' as const,
+            protocol: 'Kamino' as const,
+            symbol: 'USDC',
+            amount: 1,
+            reserveAddress: 'r1',
+            mint: 'm1',
+            summary: 's1',
+            base64Txn: 'AAAA',
+            blockhash: 'b1',
+            lastValidBlockHeight: '100',
+            status: 'pending' as const,
+          },
+        },
+        {
+          id: 'a2',
+          role: 'assistant' as const,
+          content: 'tx2',
+          timestamp: 2,
+          pendingTransaction: {
+            action: 'borrow' as const,
+            protocol: 'Kamino' as const,
+            symbol: 'SOL',
+            amount: 0.5,
+            reserveAddress: 'r2',
+            mint: 'm2',
+            summary: 's2',
+            base64Txn: 'BBBB',
+            blockhash: 'b2',
+            lastValidBlockHeight: '200',
+            status: 'pending' as const,
+          },
+        },
+      ],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    localStorage.setItem('kami_conversations', JSON.stringify([conv]));
+    localStorage.setItem('kami_active_conversation', 'c1');
+
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.updatePendingTransaction('a1', {
+        status: 'confirmed',
+        signature: 'sig-1',
+      });
+    });
+
+    const msg1 = result.current.activeConversation.messages.find((m) => m.id === 'a1');
+    const msg2 = result.current.activeConversation.messages.find((m) => m.id === 'a2');
+    expect(msg1?.pendingTransaction?.status).toBe('confirmed');
+    expect(msg1?.pendingTransaction?.signature).toBe('sig-1');
+    expect(msg2?.pendingTransaction?.status).toBe('pending');
+    expect(msg2?.pendingTransaction?.signature).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+Run: `pnpm test:run -- src/hooks/useChat.test.ts`
+
+Expected: **5 new tests fail** with `TypeError: result.current.updatePendingTransaction is not a function`. Existing tests still pass.
+
+- [ ] **Step 1.3: Implement `updatePendingTransaction` in `useChat.ts`**
+
+Open `src/hooks/useChat.ts`. Add the new method right after `renameConversation` (around line 137) and before `sendMessage` (line 139). Insert this block:
+
+```ts
+  const updatePendingTransaction = useCallback(
+    (messageId: string, patch: Partial<PendingTransaction>) => {
+      const updated = conversations.map((c) => ({
+        ...c,
+        messages: c.messages.map((m) =>
+          m.id === messageId && m.pendingTransaction
+            ? { ...m, pendingTransaction: { ...m.pendingTransaction, ...patch } }
+            : m
+        ),
+      }));
+      persist(updated);
+    },
+    [conversations, persist]
+  );
+```
+
+Then add `updatePendingTransaction` to the return object at the bottom of `useChat()` (currently around lines 324-336). The return becomes:
+
+```ts
+  return {
+    conversations,
+    activeConversation,
+    activeId,
+    isStreaming,
+    sendMessage,
+    stopStreaming,
+    newConversation,
+    switchConversation,
+    deleteConversation,
+    clearAllConversations,
+    renameConversation,
+    updatePendingTransaction, // NEW
+  };
+```
+
+- [ ] **Step 1.4: Run tests to verify all 5 pass**
+
+Run: `pnpm test:run -- src/hooks/useChat.test.ts`
+
+Expected: all useChat tests pass (existing + 5 new). Total file count: ~22 tests in this file (was 17).
+
+- [ ] **Step 1.5: Run full typecheck + suite**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm test:run
+```
+
+Expected: **all silent**, **275 tests passing** (was 270, now +5).
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add src/hooks/useChat.ts src/hooks/useChat.test.ts
+git commit -m "$(cat <<'EOF'
+feat(useChat): add updatePendingTransaction(messageId, patch)
+
+Shallow-merge patch onto target message's pendingTransaction. Idempotent
+no-op when messageId not found OR message has no pendingTransaction.
+Persists via existing saveConversations path.
+
+This is the foundation for TxStatusCard reload hydration: the card will
+call this method on each lifecycle transition (submitted/confirmed/failed)
+so the persisted state matches the on-chain reality.
+EOF
+)"
+```
+
+---
+
+### Task 2: Wire `onStatusChange` callbacks into `TxStatusCard.handleSign`
+
+**Files:**
+- Modify: `src/components/chat/TxStatusCard.tsx` (add prop, add 4 callback fires)
+- Modify: `src/components/chat/TxStatusCard.test.tsx` (append 4 callback-firing tests)
+
+**Why second:** Adds the *write* side of the persistence contract (TxStatusCard → useChat) without yet touching the *read* side (mount-time hydration), keeping diffs reviewable in two halves.
+
+- [ ] **Step 2.1: Write 4 failing tests for callback firing**
+
+Append to `src/components/chat/TxStatusCard.test.tsx` after the last `it(...)` and before the closing `});`:
+
+```ts
+  it('fires onStatusChange with submitted+signature after sendTransaction resolves', async () => {
+    wallet.sendTransaction.mockResolvedValue('sig-from-rpc-12345');
+    // First poll returns null — keeps state in broadcasting so we can assert the submitted callback fired pre-confirm.
+    connection.getSignatureStatuses.mockResolvedValue({ value: [null] });
+    connection.getBlockHeight.mockResolvedValue(50);
+    const onStatusChange = vi.fn();
+
+    render(<TxStatusCard transaction={baseTx} onStatusChange={onStatusChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /sign transaction/i }));
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledWith({
+        status: 'submitted',
+        signature: 'sig-from-rpc-12345',
+      });
+    });
+  });
+
+  it('fires onStatusChange with confirmed when poll succeeds', async () => {
+    wallet.sendTransaction.mockResolvedValue('sig-confirm-1');
+    connection.getSignatureStatuses.mockResolvedValue({
+      value: [{ confirmationStatus: 'confirmed', err: null }],
+    });
+    connection.getBlockHeight.mockResolvedValue(50);
+    const onStatusChange = vi.fn();
+
+    render(<TxStatusCard transaction={baseTx} onStatusChange={onStatusChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /sign transaction/i }));
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledWith({ status: 'confirmed' });
+    });
+  });
+
+  it('fires onStatusChange with failed+error when sendTransaction throws', async () => {
+    wallet.sendTransaction.mockRejectedValue(new Error('User rejected the request'));
+    const onStatusChange = vi.fn();
+
+    render(<TxStatusCard transaction={baseTx} onStatusChange={onStatusChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /sign transaction/i }));
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalled();
+    });
+    const lastCall = onStatusChange.mock.calls[onStatusChange.mock.calls.length - 1][0];
+    expect(lastCall.status).toBe('failed');
+    expect(typeof lastCall.error).toBe('string');
+    expect(lastCall.error.length).toBeGreaterThan(0);
+  });
+
+  it('does not throw when onStatusChange prop is omitted', async () => {
+    wallet.sendTransaction.mockResolvedValue('sig-orphan');
+    connection.getSignatureStatuses.mockResolvedValue({
+      value: [{ confirmationStatus: 'confirmed', err: null }],
+    });
+    connection.getBlockHeight.mockResolvedValue(50);
+
+    render(<TxStatusCard transaction={baseTx} />);
+    fireEvent.click(screen.getByRole('button', { name: /sign transaction/i }));
+
+    // No throw → confirmed UI eventually renders.
+    await waitFor(() => {
+      expect(screen.getByText(/confirmed/i)).toBeInTheDocument();
+    });
+  });
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+Run: `pnpm test:run -- src/components/chat/TxStatusCard.test.tsx`
+
+Expected: 3 of the 4 new tests fail (`onStatusChange` is not yet a recognized prop, calls are not made). The 4th ("does not throw when onStatusChange omitted") may pass *coincidentally* because the prop is currently ignored — that's fine, it pins the no-throw contract for after the change.
+
+- [ ] **Step 2.3: Implement onStatusChange prop + 4 fire sites in TxStatusCard.tsx**
+
+Open `src/components/chat/TxStatusCard.tsx`. Apply these 4 changes:
+
+**Change 1 — Update Props interface (around line 13):**
+
+Replace:
+```ts
+interface Props {
+  transaction: PendingTransaction;
+}
+```
+
+With:
+```ts
+interface Props {
+  transaction: PendingTransaction;
+  onStatusChange?: (patch: Partial<PendingTransaction>) => void;
+}
+```
+
+**Change 2 — Update component signature (around line 70):**
+
+Replace:
+```ts
+export default function TxStatusCard({ transaction }: Props) {
+```
+
+With:
+```ts
+export default function TxStatusCard({ transaction, onStatusChange }: Props) {
+```
+
+**Change 3 — Fire callbacks inside `handleSign` (around lines 98-134):**
+
+Replace the entire `handleSign` body with:
+
+```ts
+  const handleSign = async () => {
+    if (!connected || !publicKey) {
+      setError({ kind: 'unknown', message: 'Connect a wallet first.' });
+      setPhase('failed');
+      return;
+    }
+    setError(null);
+    setPhase('signing');
+    try {
+      const txBytes = decodeBase64ToBytes(transaction.base64Txn);
+      const tx = VersionedTransaction.deserialize(txBytes);
+      const sig = await sendTransaction(tx, connection, {
+        skipPreflight: false,
+        maxRetries: 3,
+      });
+      setSignature(sig);
+      setPhase('broadcasting');
+      onStatusChange?.({ status: 'submitted', signature: sig });
+
+      const lastValidBlockHeight = Number(transaction.lastValidBlockHeight);
+      const outcome = await pollSignatureStatus(connection, sig, lastValidBlockHeight);
+      if (cancelRef.current) return;
+
+      if (outcome.status === 'confirmed') {
+        setPhase('confirmed');
+        onStatusChange?.({ status: 'confirmed' });
+      } else {
+        const classified = classifyWalletError(new Error(outcome.reason));
+        setError(classified);
+        setPhase('failed');
+        onStatusChange?.({ status: 'failed', error: outcome.reason });
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[Kami] sendTransaction failed', err);
+      const classified = classifyWalletError(err);
+      setError(classified);
+      setPhase('failed');
+      onStatusChange?.({ status: 'failed', error: classified.message });
+    }
+  };
+```
+
+(Diff vs current: 4 added `onStatusChange?.(...)` lines — no other logic changes.)
+
+- [ ] **Step 2.4: Run tests to verify all 4 new pass + existing pass**
+
+Run: `pnpm test:run -- src/components/chat/TxStatusCard.test.tsx`
+
+Expected: all TxStatusCard tests pass (existing 5 + 4 new = 9 total in this file).
+
+- [ ] **Step 2.5: Run full typecheck + suite**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm test:run
+```
+
+Expected: **all silent**, **279 tests passing** (was 275, now +4).
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/components/chat/TxStatusCard.tsx src/components/chat/TxStatusCard.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(TxStatusCard): fire onStatusChange on lifecycle transitions
+
+Add optional onStatusChange prop. Fire-and-forget on each persistable
+transition: submitted (post-sendTransaction), confirmed (post-poll),
+failed (poll outcome OR sendTransaction throw). Optional chaining at
+all call sites — TxStatusCard remains usable in test contexts that
+don't supply the callback.
+
+Mount-time hydration (resume polling) lands in the next commit so each
+half stays reviewable independently.
+EOF
+)"
+```
+
+---
+
+### Task 3: Add resume-polling `useEffect` on mount
+
+**Files:**
+- Modify: `src/components/chat/TxStatusCard.tsx` (extend phase initializer + add useEffect)
+- Modify: `src/components/chat/TxStatusCard.test.tsx` (append 3 hydration tests)
+
+**Why third:** This depends on the prop wiring from Task 2 (the new useEffect calls `onStatusChange?.(...)` on poll outcome). Lands the *read* side of the persistence contract.
+
+- [ ] **Step 3.1: Write 3 failing tests for hydration + resume polling**
+
+Append to `src/components/chat/TxStatusCard.test.tsx`:
+
+```ts
+  it('hydrates to broadcasting and resumes polling when status=submitted+signature', async () => {
+    connection.getSignatureStatuses.mockResolvedValue({
+      value: [{ confirmationStatus: 'confirmed', err: null }],
+    });
+    connection.getBlockHeight.mockResolvedValue(50);
+    const onStatusChange = vi.fn();
+
+    const tx: PendingTransaction = {
+      ...baseTx,
+      status: 'submitted',
+      signature: 'sig-resumed-on-mount',
+    };
+    render(<TxStatusCard transaction={tx} onStatusChange={onStatusChange} />);
+
+    // No "Sign Transaction" button — we're past needs-sign.
+    expect(screen.queryByRole('button', { name: /sign transaction/i })).not.toBeInTheDocument();
+
+    // Poll runs and resolves to confirmed.
+    await waitFor(() => {
+      expect(connection.getSignatureStatuses).toHaveBeenCalledWith(
+        ['sig-resumed-on-mount'],
+        expect.any(Object)
+      );
+    });
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledWith({ status: 'confirmed' });
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/confirmed/i)).toBeInTheDocument();
+    });
+  });
+
+  it('falls back to needs-sign when status=submitted but signature is missing', () => {
+    const tx: PendingTransaction = {
+      ...baseTx,
+      status: 'submitted',
+      // signature deliberately omitted
+    };
+    render(<TxStatusCard transaction={tx} />);
+
+    // Defensive: missing signature → render Sign button so user can re-attempt.
+    expect(screen.getByRole('button', { name: /sign transaction/i })).toBeInTheDocument();
+    expect(connection.getSignatureStatuses).not.toHaveBeenCalled();
+  });
+
+  it('fires onStatusChange with failed when resumed poll detects blockhash-expired', async () => {
+    // Poll returns no signature info, then blockhash check fails.
+    connection.getSignatureStatuses.mockResolvedValue({ value: [null] });
+    connection.getBlockHeight.mockResolvedValue(99999);
+    const onStatusChange = vi.fn();
+
+    const tx: PendingTransaction = {
+      ...baseTx,
+      status: 'submitted',
+      signature: 'sig-stale',
+      lastValidBlockHeight: '100',
+    };
+    render(<TxStatusCard transaction={tx} onStatusChange={onStatusChange} />);
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalled();
+    });
+    const lastCall = onStatusChange.mock.calls[onStatusChange.mock.calls.length - 1][0];
+    expect(lastCall.status).toBe('failed');
+    expect(lastCall.error).toMatch(/blockhash expired/i);
+  });
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+Run: `pnpm test:run -- src/components/chat/TxStatusCard.test.tsx`
+
+Expected: the first and third new tests fail (no useEffect to resume polling yet, and the phase initializer doesn't recognize `submitted+signature`). The second ("falls back to needs-sign") may pass coincidentally because the phase initializer currently falls through to needs-sign anyway — that's fine, it pins the defensive contract.
+
+- [ ] **Step 3.3: Extend phase initializer + add resume-polling useEffect in TxStatusCard.tsx**
+
+Open `src/components/chat/TxStatusCard.tsx`. Apply two changes:
+
+**Change A — Extend phase initializer (around lines 74-84):**
+
+Replace:
+```ts
+  const [phase, setPhase] = useState<Phase>(() => {
+    if (transaction.status === 'confirmed' && transaction.signature) return 'confirmed';
+    if (
+      transaction.status === 'failed' ||
+      transaction.status === 'cancelled' ||
+      transaction.error
+    ) {
+      return 'failed';
+    }
+    return 'needs-sign';
+  });
+```
+
+With:
+```ts
+  const [phase, setPhase] = useState<Phase>(() => {
+    if (transaction.status === 'confirmed' && transaction.signature) return 'confirmed';
+    if (transaction.status === 'submitted' && transaction.signature) return 'broadcasting';
+    if (
+      transaction.status === 'failed' ||
+      transaction.status === 'cancelled' ||
+      transaction.error
+    ) {
+      return 'failed';
+    }
+    return 'needs-sign';
+  });
+```
+
+**Change B — Insert mount-only resume `useEffect`** right after the existing cleanup `useEffect` (around lines 91-96). The cleanup useEffect is:
+
+```ts
+  useEffect(
+    () => () => {
+      cancelRef.current = true;
+    },
+    []
+  );
+```
+
+Add immediately after it:
+
+```ts
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (transaction.status !== 'submitted' || !transaction.signature) return;
+    const sig = transaction.signature;
+    const lastValidBlockHeight = Number(transaction.lastValidBlockHeight);
+    let active = true;
+    pollSignatureStatus(connection, sig, lastValidBlockHeight).then((outcome) => {
+      if (!active || cancelRef.current) return;
+      if (outcome.status === 'confirmed') {
+        setPhase('confirmed');
+        onStatusChange?.({ status: 'confirmed' });
+      } else {
+        const classified = classifyWalletError(new Error(outcome.reason));
+        setError(classified);
+        setPhase('failed');
+        onStatusChange?.({ status: 'failed', error: outcome.reason });
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, []); // mount-only resume — never re-runs
+```
+
+The empty-deps array is deliberate — this is one-shot resume logic; subsequent transitions are driven by `handleSign`. Reading from `transaction.*` (props) rather than `phase`/`signature` (state) makes the intent explicit. The phase initializer above already mapped `status==='submitted' + signature` → `'broadcasting'`, so the UI is consistent when this effect runs.
+
+- [ ] **Step 3.4: Run tests to verify all 3 new pass + existing pass**
+
+Run: `pnpm test:run -- src/components/chat/TxStatusCard.test.tsx`
+
+Expected: all TxStatusCard tests pass (existing 9 + 3 new = 12 total in this file).
+
+- [ ] **Step 3.5: Run full typecheck + suite**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm test:run
+```
+
+Expected: **all silent**, **282 tests passing** (was 279, now +3).
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add src/components/chat/TxStatusCard.tsx src/components/chat/TxStatusCard.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(TxStatusCard): resume polling on mount when status=submitted+signature
+
+Extend phase initializer with the broadcasting branch (status='submitted'
++ signature). New mount-only useEffect kicks pollSignatureStatus once
+with the persisted signature + lastValidBlockHeight. On confirmed →
+fires onStatusChange({status:'confirmed'}); on poll failure (incl.
+blockhash-expired) → fires onStatusChange({status:'failed', error}).
+
+Empty-deps useEffect is deliberate — one-shot resume; subsequent
+transitions driven by handleSign. Reads transaction.* (props) rather
+than state to make intent explicit.
+
+Closes the duplicate-sign window on reload: a user who reloads while
+the tx is in flight no longer sees Sign Transaction (which would
+double-broadcast); they see the actual broadcasting state with
+auto-resumed polling that resolves cleanly to confirmed or failed.
+EOF
+)"
+```
+
+---
+
+### Task 4: Wire `onPendingTransactionChange` through MessageBubble + App.tsx
+
+**Files:**
+- Modify: `src/components/chat/MessageBubble.tsx` (add prop, forward as closure)
+- Modify: `src/App.tsx` (destructure `updatePendingTransaction`, pass as prop)
+- Modify: `src/components/chat/MessageBubble.test.tsx` (extend mock + 2 pass-through tests)
+
+**Why last:** Every layer beneath this is now contract-tested. Wiring is one-line on both sides; failure modes are localized.
+
+- [ ] **Step 4.1: Update MessageBubble test mock to capture TxStatusCard props**
+
+The current mock at line 8-10 ignores props entirely:
+```ts
+vi.mock('./TxStatusCard', () => ({
+  default: () => <div data-testid="tx-card" />,
+}));
+```
+
+We need to capture the `onStatusChange` prop. Replace the mock with:
+
+```ts
+const txCardProps = vi.hoisted(() => ({ lastOnStatusChange: null as ((p: unknown) => void) | null }));
+
+vi.mock('./TxStatusCard', () => ({
+  default: ({ onStatusChange }: { onStatusChange?: (p: unknown) => void }) => {
+    txCardProps.lastOnStatusChange = onStatusChange ?? null;
+    return <div data-testid="tx-card" />;
+  },
+}));
+```
+
+Place this immediately after the existing `vi.mock('../../lib/markdown', ...)` block and before the existing `vi.mock('./TxStatusCard', ...)` (which you delete). The `vi.hoisted` ensures `txCardProps` is reachable in test bodies.
+
+- [ ] **Step 4.2: Write 2 failing tests for prop forwarding**
+
+Append to `src/components/chat/MessageBubble.test.tsx` after the last `it(...)`:
+
+```ts
+  it('forwards onPendingTransactionChange to TxStatusCard, capturing message id in closure', () => {
+    const onPendingTransactionChange = vi.fn();
+    const msg: ChatMessage = {
+      ...assistantMsg,
+      id: 'msg-with-tx',
+      pendingTransaction: {
+        action: 'deposit',
+        protocol: 'Kamino',
+        symbol: 'USDC',
+        amount: 5,
+        reserveAddress: 'r1',
+        mint: 'm1',
+        summary: 's1',
+        base64Txn: 'AAAA',
+        blockhash: 'b1',
+        lastValidBlockHeight: '100',
+      },
+    };
+    render(
+      <MessageBubble
+        message={msg}
+        isStreaming={false}
+        onPendingTransactionChange={onPendingTransactionChange}
+      />
+    );
+
+    // The mock captured the closure that the parent passed to TxStatusCard.
+    expect(txCardProps.lastOnStatusChange).toBeDefined();
+    txCardProps.lastOnStatusChange!({ status: 'confirmed' });
+
+    // The closure invoked the parent callback with the message id.
+    expect(onPendingTransactionChange).toHaveBeenCalledWith('msg-with-tx', { status: 'confirmed' });
+  });
+
+  it('passes undefined onStatusChange when onPendingTransactionChange is omitted', () => {
+    const msg: ChatMessage = {
+      ...assistantMsg,
+      pendingTransaction: {
+        action: 'deposit',
+        protocol: 'Kamino',
+        symbol: 'USDC',
+        amount: 5,
+        reserveAddress: 'r1',
+        mint: 'm1',
+        summary: 's1',
+        base64Txn: 'AAAA',
+        blockhash: 'b1',
+        lastValidBlockHeight: '100',
+      },
+    };
+    txCardProps.lastOnStatusChange = null; // reset before render
+    render(<MessageBubble message={msg} isStreaming={false} />);
+    expect(txCardProps.lastOnStatusChange).toBeNull();
+  });
+```
+
+- [ ] **Step 4.3: Run tests to verify they fail**
+
+Run: `pnpm test:run -- src/components/chat/MessageBubble.test.tsx`
+
+Expected: 2 new tests fail (`MessageBubble` doesn't accept `onPendingTransactionChange`, doesn't forward it). Existing 7 tests still pass.
+
+- [ ] **Step 4.4: Implement MessageBubble prop forwarding**
+
+Open `src/components/chat/MessageBubble.tsx`. Apply two changes:
+
+**Change A — Update Props interface and add import (lines 1-13):**
+
+Replace:
+```ts
+import { Markdown } from '../../lib/markdown';
+import BentoCell from '../bento/BentoCell';
+import KamiCursor from '../bento/KamiCursor';
+import ToolBadge from './ToolBadge';
+import TxStatusCard from './TxStatusCard';
+import ConnectWalletButton from '../ConnectWalletButton';
+import { groupToolCalls } from './groupToolCalls';
+import type { ChatMessage } from '../../types';
+
+interface Props {
+  message: ChatMessage;
+  isStreaming: boolean;
+}
+```
+
+With:
+```ts
+import { Markdown } from '../../lib/markdown';
+import BentoCell from '../bento/BentoCell';
+import KamiCursor from '../bento/KamiCursor';
+import ToolBadge from './ToolBadge';
+import TxStatusCard from './TxStatusCard';
+import ConnectWalletButton from '../ConnectWalletButton';
+import { groupToolCalls } from './groupToolCalls';
+import type { ChatMessage, PendingTransaction } from '../../types';
+
+interface Props {
+  message: ChatMessage;
+  isStreaming: boolean;
+  onPendingTransactionChange?: (messageId: string, patch: Partial<PendingTransaction>) => void;
+}
+```
+
+**Change B — Update component signature + TxStatusCard render (line 15 + line 64):**
+
+Replace:
+```ts
+export default function MessageBubble({ message, isStreaming }: Props) {
+```
+
+With:
+```ts
+export default function MessageBubble({ message, isStreaming, onPendingTransactionChange }: Props) {
+```
+
+Replace (around line 64):
+```tsx
+        {message.pendingTransaction && (
+          <div className="mt-3">
+            <TxStatusCard transaction={message.pendingTransaction} />
+          </div>
+        )}
+```
+
+With:
+```tsx
+        {message.pendingTransaction && (
+          <div className="mt-3">
+            <TxStatusCard
+              transaction={message.pendingTransaction}
+              onStatusChange={
+                onPendingTransactionChange
+                  ? (patch) => onPendingTransactionChange(message.id, patch)
+                  : undefined
+              }
+            />
+          </div>
+        )}
+```
+
+- [ ] **Step 4.5: Run MessageBubble tests to verify all pass**
+
+Run: `pnpm test:run -- src/components/chat/MessageBubble.test.tsx`
+
+Expected: all MessageBubble tests pass (existing 7 + 2 new = 9 total).
+
+- [ ] **Step 4.6: Wire updatePendingTransaction through App.tsx**
+
+Open `src/App.tsx`. Apply two changes:
+
+**Change A — Add to useChat destructure (around lines 19-29):**
+
+Replace:
+```ts
+    activeId,
+    isStreaming,
+    sendMessage,
+    stopStreaming,
+    newConversation,
+    switchConversation,
+    deleteConversation,
+    clearAllConversations,
+    renameConversation,
+  } = useChat();
+```
+
+With:
+```ts
+    activeId,
+    isStreaming,
+    sendMessage,
+    stopStreaming,
+    newConversation,
+    switchConversation,
+    deleteConversation,
+    clearAllConversations,
+    renameConversation,
+    updatePendingTransaction,
+  } = useChat();
+```
+
+**Change B — Pass onPendingTransactionChange to MessageBubble (around line 80-88):**
+
+Replace:
+```tsx
+              {activeConversation.messages.map((msg, idx) => (
+                <MessageBubble
+                  key={msg.id}
+                  message={msg}
+                  isStreaming={
+                    isStreaming &&
+                    msg.role === 'assistant' &&
+                    idx === activeConversation.messages.length - 1
+                  }
+                />
+              ))}
+```
+
+With:
+```tsx
+              {activeConversation.messages.map((msg, idx) => (
+                <MessageBubble
+                  key={msg.id}
+                  message={msg}
+                  isStreaming={
+                    isStreaming &&
+                    msg.role === 'assistant' &&
+                    idx === activeConversation.messages.length - 1
+                  }
+                  onPendingTransactionChange={updatePendingTransaction}
+                />
+              ))}
+```
+
+- [ ] **Step 4.7: Run full typecheck + suite + build**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec tsc -p server/tsconfig.json --noEmit
+pnpm exec tsc -b
+pnpm test:run
+pnpm build
+```
+
+Expected: **all silent**, **284 tests passing** (was 282, now +2). Build clean.
+
+- [ ] **Step 4.8: Commit**
+
+```bash
+git add src/components/chat/MessageBubble.tsx src/components/chat/MessageBubble.test.tsx src/App.tsx
+git commit -m "$(cat <<'EOF'
+feat(chat): wire onPendingTransactionChange through MessageBubble + App
+
+Final wiring step. App.tsx destructures updatePendingTransaction from
+useChat and forwards it to MessageBubble. MessageBubble accepts the
+optional onPendingTransactionChange prop and bridges into TxStatusCard's
+onStatusChange via a closure that captures message.id.
+
+Closes the contract end-to-end: TxStatusCard transitions →
+onStatusChange(patch) → MessageBubble closure → updatePendingTransaction
+(message.id, patch) → useChat persists → reload reads back correctly.
+
+Test mock for TxStatusCard updated to capture the onStatusChange prop so
+the prop-forwarding contract is verified directly.
+EOF
+)"
+```
+
+---
+
+## Post-flight (run once after Task 4)
+
+- [ ] **Verify test count**: `pnpm test:run` → **284 passing across 39 files** (was 270 + 14 new = 284).
+- [ ] **Verify branch state**: `git log --oneline fix/txstatuscard-reload-hydration ^main` → expect 6 commits (1 spec + 1 self-review + 4 feature).
+- [ ] **Verify no regressions**: open the production-state assistant flow in localdev (`pnpm dev` → http://localhost:5173 → connect → deposit). Confirm the happy-path tx flow still works end-to-end (needs-sign → signing → broadcasting → confirmed). Reload mid-broadcasting → verify it resumes polling rather than reverting to needs-sign.
+
+---
+
+## File summary
+
+| File | Operation | Tests added |
+|---|---|---|
+| `src/hooks/useChat.ts` | modify (add `updatePendingTransaction`) | — |
+| `src/hooks/useChat.test.ts` | extend (+5 tests) | 5 |
+| `src/components/chat/TxStatusCard.tsx` | modify (prop, 4 callback fires, hydration branch, useEffect) | — |
+| `src/components/chat/TxStatusCard.test.tsx` | extend (+7 tests) | 7 |
+| `src/components/chat/MessageBubble.tsx` | modify (prop, closure forward) | — |
+| `src/components/chat/MessageBubble.test.tsx` | extend (mock update + 2 tests) | 2 |
+| `src/App.tsx` | modify (destructure + forward) | — |
+
+**Totals:** 4 source files modified + 3 test files extended + 1 spec doc + 1 plan doc = 9 files. Test delta: **+14**, taking the suite from **270 → 284**. Bundle delta: negligible (callback chain + tiny useEffect, no new dependencies).
+
+---
+
+## Out-of-band cleanup (NOT part of this plan)
+
+These items are pre-existing tech debt mentioned in CLAUDE.md or session handoffs and should NOT be folded into this PR:
+
+- CLAUDE.md:227-236 file-map references deleted ChatPanel/Sidebar/etc. (Day-21 leftover)
+- 9 deferred minors from Day 20-21 chat-shell PR reviews (#46 umbrella)
+- D-27 useChat `[DONE]` SSE chunk inner-for-break (#45)
+- Empty-msg-on-abort cosmetic UX (#39)
+
+If the implementer notices these during review, file separately or leave alone — they're not in scope.

--- a/docs/superpowers/specs/2026-05-01-txstatuscard-reload-hydration-design.md
+++ b/docs/superpowers/specs/2026-05-01-txstatuscard-reload-hydration-design.md
@@ -95,14 +95,15 @@ const [phase, setPhase] = useState<Phase>(() => {
 });
 ```
 
-**New `useEffect` on mount** — when initial phase is `'broadcasting'` AND a signature is present, resume polling:
+**New `useEffect` on mount** — when persisted state is `'submitted'` with a signature, resume polling:
 
 ```ts
 useEffect(() => {
-  if (phase !== 'broadcasting' || !signature) return;
+  if (transaction.status !== 'submitted' || !transaction.signature) return;
+  const sig = transaction.signature;
   const lastValidBlockHeight = Number(transaction.lastValidBlockHeight);
   let active = true;
-  pollSignatureStatus(connection, signature, lastValidBlockHeight).then((outcome) => {
+  pollSignatureStatus(connection, sig, lastValidBlockHeight).then((outcome) => {
     if (!active || cancelRef.current) return;
     if (outcome.status === 'confirmed') {
       setPhase('confirmed');
@@ -116,10 +117,10 @@ useEffect(() => {
   });
   return () => { active = false; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-}, []); // mount-only; do not re-run on prop change
+}, []); // mount-only resume — never re-runs
 ```
 
-The empty-deps array is deliberate — this is one-shot resume logic; subsequent transitions are driven by `handleSign`. We carefully NOT re-fire on prop change because `transaction.signature` may legitimately update (via the parent re-render after the persist round-trip).
+The empty-deps array is deliberate — this is one-shot resume logic; subsequent transitions are driven by `handleSign`. Reading from `transaction.*` (props) rather than `phase`/`signature` (state) makes the intent explicit: "if mounted in `'submitted'` state, kick the poll once". The phase initializer above already mapped `status==='submitted' + signature` → `'broadcasting'`, so the UI is in the right state when this effect runs.
 
 **`onStatusChange` calls inside `handleSign`** — fire-and-forget at three points:
 

--- a/docs/superpowers/specs/2026-05-01-txstatuscard-reload-hydration-design.md
+++ b/docs/superpowers/specs/2026-05-01-txstatuscard-reload-hydration-design.md
@@ -1,0 +1,348 @@
+# Spec — TxStatusCard Reload Hydration
+
+**Date:** 2026-05-01
+**Branch:** `fix/txstatuscard-reload-hydration`
+**Origin:** Bug discovered during Day 21 Chrome MCP financial QA on `kami.rectorspace.com` after the PR #49 chat-shell amber redesign. Out-of-scope finding from `/quality:qa` style sweep.
+
+---
+
+## Problem
+
+When a Kamino transaction confirms on-chain, the user reloads the page, and the **TxStatusCard reverts to `'needs-sign'` state** — even though the deposit is already finalized on-chain. The "Sign Transaction" button reappears.
+
+Worst-case impact: a user who reloads waiting for confirmation can sign the transaction a second time. Solana's blockhash dedup makes a true double-spend rare, but the UX is wrong and creates support load ("did my deposit go through?").
+
+**Root cause:** `TxStatusCard.tsx:74-89` keeps `phase` and `signature` in component-local `useState`. `useChat.ts:272` writes `pendingTransaction = { ...output.data, status: 'pending' }` exactly once when the build* tool result arrives, and **nothing ever updates the persisted message** as the card transitions through signing → broadcasting → confirmed/failed. After reload, the persisted `status` is still `'pending'`, so the phase initializer falls through to `'needs-sign'`.
+
+---
+
+## Goal
+
+Persist the transaction lifecycle through the `'submitted' | 'confirmed' | 'failed'` states so TxStatusCard hydrates correctly across:
+
+1. Page reload
+2. Conversation switch (component unmount/remount)
+3. Tab refocus after long idle
+
+For any transaction that was signed but not yet confirmed at the time of unmount, **resume `pollSignatureStatus`** on remount using the persisted `signature` + `lastValidBlockHeight`.
+
+---
+
+## Non-Goals
+
+- Persisting transient `'signing'` state — the wallet popup window is sub-3-second; not worth the noise of an extra persist call. UI still shows `'signing'` locally.
+- Persisting `'cancelled'` state — user dismissed the popup; reverting to `'needs-sign'` lets them re-attempt cleanly.
+- Cross-tab synchronization (`storage` events) — pre-existing limitation of the `localStorage`-backed conversation store.
+- Detecting stale tx pre-retry — if the user clicks Retry on a card whose blockhash has expired, `pollSignatureStatus` returns `'failed'` with `'Blockhash expired before confirmation.'`. Lazy-fail with a clear message is fine.
+- Multi-tab race when two open tabs persist different states — same pre-existing limitation; not worsened by this change.
+
+---
+
+## Architecture
+
+Three surfaces touched. **Zero schema changes** — `PendingTransaction.status` enum already includes `'submitted' | 'confirmed' | 'failed'` and `signature` is already optional in `src/types.ts:12-28`.
+
+### Surface 1 — `src/hooks/useChat.ts`
+
+Add a new method:
+
+```ts
+const updatePendingTransaction = useCallback(
+  (messageId: string, patch: Partial<PendingTransaction>) => {
+    const updated = conversations.map((c) => ({
+      ...c,
+      messages: c.messages.map((m) =>
+        m.id === messageId && m.pendingTransaction
+          ? { ...m, pendingTransaction: { ...m.pendingTransaction, ...patch } }
+          : m
+      ),
+    }));
+    persist(updated);
+  },
+  [conversations, persist]
+);
+```
+
+Behavior:
+- Idempotent no-op when `messageId` is not found in any conversation.
+- Idempotent no-op when the message exists but has no `pendingTransaction` (defensive — never creates an empty pendingTransaction).
+- Shallow merge: patch values overwrite, untouched fields like `base64Txn`, `mint`, `summary` are preserved.
+- Persists via the existing `persist()` closure (same path as `sendMessage`).
+
+Returned alongside existing methods at the bottom of `useChat()`.
+
+### Surface 2 — `src/components/chat/TxStatusCard.tsx`
+
+**New optional prop:**
+
+```ts
+interface Props {
+  transaction: PendingTransaction;
+  onStatusChange?: (patch: Partial<PendingTransaction>) => void;
+}
+```
+
+**Phase initializer extended** — adds one new branch above the fall-through:
+
+```ts
+const [phase, setPhase] = useState<Phase>(() => {
+  if (transaction.status === 'confirmed' && transaction.signature) return 'confirmed';
+  if (transaction.status === 'submitted' && transaction.signature) return 'broadcasting'; // NEW
+  if (transaction.status === 'failed' || transaction.status === 'cancelled' || transaction.error) {
+    return 'failed';
+  }
+  return 'needs-sign';
+});
+```
+
+**New `useEffect` on mount** — when initial phase is `'broadcasting'` AND a signature is present, resume polling:
+
+```ts
+useEffect(() => {
+  if (phase !== 'broadcasting' || !signature) return;
+  const lastValidBlockHeight = Number(transaction.lastValidBlockHeight);
+  let active = true;
+  pollSignatureStatus(connection, signature, lastValidBlockHeight).then((outcome) => {
+    if (!active || cancelRef.current) return;
+    if (outcome.status === 'confirmed') {
+      setPhase('confirmed');
+      onStatusChange?.({ status: 'confirmed' });
+    } else {
+      const classified = classifyWalletError(new Error(outcome.reason));
+      setError(classified);
+      setPhase('failed');
+      onStatusChange?.({ status: 'failed', error: outcome.reason });
+    }
+  });
+  return () => { active = false; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, []); // mount-only; do not re-run on prop change
+```
+
+The empty-deps array is deliberate — this is one-shot resume logic; subsequent transitions are driven by `handleSign`. We carefully NOT re-fire on prop change because `transaction.signature` may legitimately update (via the parent re-render after the persist round-trip).
+
+**`onStatusChange` calls inside `handleSign`** — fire-and-forget at three points:
+
+```ts
+// After sendTransaction resolves:
+setSignature(sig);
+setPhase('broadcasting');
+onStatusChange?.({ status: 'submitted', signature: sig });
+
+// After pollSignatureStatus succeeds:
+setPhase('confirmed');
+onStatusChange?.({ status: 'confirmed' });
+
+// After pollSignatureStatus fails:
+setError(classified);
+setPhase('failed');
+onStatusChange?.({ status: 'failed', error: outcome.reason });
+
+// In the catch block:
+setError(classified);
+setPhase('failed');
+onStatusChange?.({ status: 'failed', error: classified.message });
+```
+
+All call sites use optional chaining — TxStatusCard remains usable in test contexts that don't supply the callback.
+
+### Surface 3 — `src/components/chat/MessageBubble.tsx` + `src/App.tsx`
+
+**MessageBubble** — accept new optional prop and forward as a closure:
+
+```ts
+interface Props {
+  message: ChatMessage;
+  isStreaming: boolean;
+  onPendingTransactionChange?: (messageId: string, patch: Partial<PendingTransaction>) => void;
+}
+
+// in render:
+<TxStatusCard
+  transaction={message.pendingTransaction}
+  onStatusChange={
+    onPendingTransactionChange
+      ? (patch) => onPendingTransactionChange(message.id, patch)
+      : undefined
+  }
+/>
+```
+
+**App.tsx** — destructure `updatePendingTransaction` from `useChat()` (line ~29) and pass to MessageBubble (line ~80):
+
+```ts
+const {
+  // ... existing destructures
+  updatePendingTransaction, // NEW
+} = useChat();
+
+// ...
+
+<MessageBubble
+  key={msg.id}
+  message={msg}
+  isStreaming={...}
+  onPendingTransactionChange={updatePendingTransaction} // NEW
+/>
+```
+
+---
+
+## Data flow
+
+### Happy-path lifecycle (no reload)
+
+```
+1. Build* tool stream finishes
+   useChat:272 sets pendingTransaction = { ...output.data, status: 'pending' }
+   → message persisted with status='pending', signature=undefined
+   → TxStatusCard renders phase='needs-sign'
+
+2. User clicks Sign
+   → setPhase('signing')   [UI only — NOT persisted]
+
+3. sendTransaction resolves with sig
+   → setSignature(sig); setPhase('broadcasting')
+   → onStatusChange({ status: 'submitted', signature: sig })   [PERSISTED]
+
+4. pollSignatureStatus resolves
+   confirmed: setPhase('confirmed'); onStatusChange({ status: 'confirmed' })
+   failed:    setError(...); setPhase('failed'); onStatusChange({ status: 'failed', error })
+
+5. (or) sendTransaction throws (popup dismissed, network)
+   → setError(...); setPhase('failed')
+   → onStatusChange({ status: 'failed', error: classified.message })   [PERSISTED]
+```
+
+### Reload paths
+
+| Persisted state at unload | Initial phase on remount | Behavior |
+|---|---|---|
+| `status='pending'`, no signature | `needs-sign` | Show Sign button. Existing behavior, no duplicate-sign risk because user deliberately re-attempts. |
+| **`status='submitted'`, signature present** | **`broadcasting` (NEW)** | useEffect resumes `pollSignatureStatus(connection, signature, lastValidBlockHeight)`. Resolves quickly to confirmed (sig already on-chain) or fast-fails on blockhash-expired. **Closes the duplicate-sign window.** |
+| `status='confirmed'`, signature present | `confirmed` (existing) | Renders Solscan link, no action. |
+| `status='failed'`, error present | `failed` (existing) | Renders error + Retry button. |
+
+### Conversation switch behavior
+
+The existing `useEffect(() => () => { cancelRef.current = true; }, [])` cleanup fires on unmount, aborting the local async loop in `handleSign` AND the new resume `useEffect`. On switch back, the new `useEffect` re-runs (new mount), sees `status==='submitted'` + signature, resumes polling from scratch. Same mechanism as page reload.
+
+### Race we accept
+
+Sub-millisecond window between `setSignature(sig)` and `onStatusChange({status:'submitted', sig})`. If the user reloads in this exact window, persisted state stays `'pending'`, so on reload they see the Sign button again. If they re-sign:
+- Same blockhash + same instructions + same signer → Solana RPC returns "already processed" or rejects with duplicate-tx error.
+- Wallet may show its own warning before broadcasting.
+
+This is acceptable because (a) the window is extremely small, (b) Solana's dedup catches the actual double-spend, (c) synchronizing harder (e.g., persist BEFORE setSignature) trades off latency for negligible safety.
+
+---
+
+## Error handling
+
+### `updatePendingTransaction` defensive no-ops
+
+- `messageId` not found in any conversation → silent no-op. No log spam (could happen during conversation deletion races).
+- Message exists but has no `pendingTransaction` field → silent no-op via the `&& m.pendingTransaction` guard. Prevents accidentally creating empty pendingTransaction objects on unrelated messages.
+- `localStorage.setItem` failure inside `saveConversations` → existing behavior preserved. Out of scope to add new try/catch here.
+
+### Resume-polling edge cases
+
+- **Blockhash already expired at remount:** `pollSignatureStatus` checks `currentHeight > lastValidBlockHeight` and returns `{status:'failed', reason:'Blockhash expired before confirmation.'}` within ~2-4 seconds. UI flips to `'failed'` with retry button. The retry on a stale tx will fail again immediately for the same reason — outside scope to detect-and-disable.
+- **Signature already finalized:** `getSignatureStatuses` returns `confirmationStatus: 'confirmed' | 'finalized'` on first poll → resolves within `POLL_INTERVAL_MS` (2s). UI flickers `'broadcasting'` → `'confirmed'`.
+- **RPC transient error during resume:** existing inner try/catch in `pollSignatureStatus` swallows + warns + retries. No new code path.
+- **Component unmounts mid-resume:** existing `cancelRef.current = true` cleanup fires. The `if (!active || cancelRef.current) return` guard prevents post-unmount setState. The new useEffect's `active = false` cleanup adds defense-in-depth.
+
+### `onStatusChange` invariants
+
+- Always optional — TxStatusCard works in test contexts without provider.
+- Patch is shallow and concrete — never sends `undefined` for fields that should be set; `status` and `signature` are always real values when persisted.
+
+---
+
+## Out of scope (deliberate)
+
+- **Stale-tx pre-retry detection** — surfacing "this transaction is too old, ask Kami to rebuild it" before the retry click. Existing lazy-fail behavior (retry → blockhash-expired → user understands) is acceptable.
+- **Multiple TxStatusCards in same conversation** — currently impossible (one `pendingTransaction` per message; one TxStatusCard per message).
+- **Cross-tab sync via `storage` events** — pre-existing limitation, not introduced by this change.
+- **Persist `signing` and `cancelled`** — see Non-Goals above.
+
+---
+
+## Testing
+
+Tests are mandatory per the project's CLAUDE.md (80%+ coverage on new code). Distribution:
+
+### `src/hooks/useChat.test.ts` — +5 tests
+
+- `updatePendingTransaction` patches the target message's `pendingTransaction` only
+- merges patch shallowly (preserves `base64Txn`, `mint`, etc.)
+- persists via `saveConversations` (verify `localStorage` mock updated)
+- no-op when `messageId` not found in any conversation
+- no-op when message exists but has no `pendingTransaction` (does NOT create one)
+
+### `src/components/chat/TxStatusCard.test.tsx` — +7 tests
+
+- `onStatusChange` fires `{status:'submitted', signature}` after `sendTransaction` resolves
+- `onStatusChange` fires `{status:'confirmed'}` after poll succeeds
+- `onStatusChange` fires `{status:'failed', error}` after poll fails (blockhash-expired path)
+- `onStatusChange` fires `{status:'failed', error}` after `sendTransaction` throws
+- mount with `status='submitted' + signature` → initial phase is `'broadcasting'`, polling kicks off (verify mock `getSignatureStatuses` called)
+- mount with `status='submitted'` but **no signature** → falls back to `'needs-sign'` (defensive guard)
+- omitted `onStatusChange` prop → no errors thrown on transitions
+
+### `src/components/chat/MessageBubble.test.tsx` — +2 tests
+
+- `onPendingTransactionChange` forwarded to TxStatusCard with closure capturing `message.id`
+- omitted prop → TxStatusCard receives `undefined` for `onStatusChange`, still renders normally
+
+### Mocks to extend
+
+- `connection.getSignatureStatuses` — already mocked in existing TxStatusCard tests (extend with confirmed-on-first-call shape).
+- `connection.getBlockHeight` — already mocked.
+- `saveConversations` from `lib/storage` — already mocked in useChat tests.
+
+### Test count delta
+
+270 → **~284** (+14 across 3 existing test files; **no new test files**).
+
+### CI commands
+
+```bash
+pnpm exec tsc --noEmit                         # client typecheck
+pnpm exec tsc -p server/tsconfig.json --noEmit # server typecheck
+pnpm exec tsc -b                               # both, project mode (matches Vercel)
+pnpm test:run                                   # full vitest suite
+pnpm build                                      # tsc -b + vite build
+```
+
+---
+
+## File list
+
+**Source (modify):**
+- `src/hooks/useChat.ts`
+- `src/components/chat/TxStatusCard.tsx`
+- `src/components/chat/MessageBubble.tsx`
+- `src/App.tsx`
+
+**Tests (extend):**
+- `src/hooks/useChat.test.ts`
+- `src/components/chat/TxStatusCard.test.tsx`
+- `src/components/chat/MessageBubble.test.tsx`
+
+**Docs (new):**
+- `docs/superpowers/specs/2026-05-01-txstatuscard-reload-hydration-design.md` (this file)
+- `docs/superpowers/plans/2026-05-01-txstatuscard-reload-hydration-implementation.md` (next, via writing-plans skill)
+
+**Total:** 4 source + 3 test + 2 doc = **9 files**.
+
+---
+
+## Implementation order (preview for the plan)
+
+1. **Add `updatePendingTransaction` to useChat** + 5 unit tests (no UI integration yet, isolated module).
+2. **Wire `onStatusChange` into TxStatusCard** + 4 callback-firing tests (no resume-polling yet).
+3. **Add resume-polling useEffect to TxStatusCard** + 3 mount-state tests.
+4. **Wire `onPendingTransactionChange` through MessageBubble + App.tsx** + 2 pass-through tests.
+
+Each task is independently committable, two-stage reviewable (general-purpose spec compliance + opus code quality), and ships a coherent slice of the fix. Plan to follow via writing-plans skill.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ function AppContent() {
     deleteConversation,
     clearAllConversations,
     renameConversation,
+    updatePendingTransaction,
   } = useChat();
 
   useEffect(() => {
@@ -85,6 +86,7 @@ function AppContent() {
                     msg.role === 'assistant' &&
                     idx === activeConversation.messages.length - 1
                   }
+                  onPendingTransactionChange={updatePendingTransaction}
                 />
               ))}
               <div ref={messagesEndRef} />

--- a/src/components/chat/MessageBubble.test.tsx
+++ b/src/components/chat/MessageBubble.test.tsx
@@ -5,8 +5,13 @@ vi.mock('../../lib/markdown', () => ({
   Markdown: ({ text }: { text: string }) => <span data-testid="md">{text}</span>,
 }));
 
+const txCardProps = vi.hoisted(() => ({ lastOnStatusChange: null as ((p: unknown) => void) | null }));
+
 vi.mock('./TxStatusCard', () => ({
-  default: () => <div data-testid="tx-card" />,
+  default: ({ onStatusChange }: { onStatusChange?: (p: unknown) => void }) => {
+    txCardProps.lastOnStatusChange = onStatusChange ?? null;
+    return <div data-testid="tx-card" />;
+  },
 }));
 
 vi.mock('../ConnectWalletButton', () => ({
@@ -97,5 +102,60 @@ describe('MessageBubble', () => {
     const { container } = render(<MessageBubble message={msg} isStreaming={true} />);
     expect(container.querySelector('[class*="animate-blink"]')).toBeInTheDocument();
     expect(screen.queryByTestId('md')).not.toBeInTheDocument();
+  });
+
+  it('forwards onPendingTransactionChange to TxStatusCard, capturing message id in closure', () => {
+    const onPendingTransactionChange = vi.fn();
+    const msg: ChatMessage = {
+      ...assistantMsg,
+      id: 'msg-with-tx',
+      pendingTransaction: {
+        action: 'deposit',
+        protocol: 'Kamino',
+        symbol: 'USDC',
+        amount: 5,
+        reserveAddress: 'r1',
+        mint: 'm1',
+        summary: 's1',
+        base64Txn: 'AAAA',
+        blockhash: 'b1',
+        lastValidBlockHeight: '100',
+      },
+    };
+    render(
+      <MessageBubble
+        message={msg}
+        isStreaming={false}
+        onPendingTransactionChange={onPendingTransactionChange}
+      />
+    );
+
+    // The mock captured the closure that the parent passed to TxStatusCard.
+    expect(txCardProps.lastOnStatusChange).toBeDefined();
+    txCardProps.lastOnStatusChange!({ status: 'confirmed' });
+
+    // The closure invoked the parent callback with the message id.
+    expect(onPendingTransactionChange).toHaveBeenCalledWith('msg-with-tx', { status: 'confirmed' });
+  });
+
+  it('passes undefined onStatusChange when onPendingTransactionChange is omitted', () => {
+    const msg: ChatMessage = {
+      ...assistantMsg,
+      pendingTransaction: {
+        action: 'deposit',
+        protocol: 'Kamino',
+        symbol: 'USDC',
+        amount: 5,
+        reserveAddress: 'r1',
+        mint: 'm1',
+        summary: 's1',
+        base64Txn: 'AAAA',
+        blockhash: 'b1',
+        lastValidBlockHeight: '100',
+      },
+    };
+    txCardProps.lastOnStatusChange = null; // reset before render
+    render(<MessageBubble message={msg} isStreaming={false} />);
+    expect(txCardProps.lastOnStatusChange).toBeNull();
   });
 });

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -5,14 +5,15 @@ import ToolBadge from './ToolBadge';
 import TxStatusCard from './TxStatusCard';
 import ConnectWalletButton from '../ConnectWalletButton';
 import { groupToolCalls } from './groupToolCalls';
-import type { ChatMessage } from '../../types';
+import type { ChatMessage, PendingTransaction } from '../../types';
 
 interface Props {
   message: ChatMessage;
   isStreaming: boolean;
+  onPendingTransactionChange?: (messageId: string, patch: Partial<PendingTransaction>) => void;
 }
 
-export default function MessageBubble({ message, isStreaming }: Props) {
+export default function MessageBubble({ message, isStreaming, onPendingTransactionChange }: Props) {
   const isUser = message.role === 'user';
 
   if (isUser) {
@@ -61,7 +62,14 @@ export default function MessageBubble({ message, isStreaming }: Props) {
         )}
         {message.pendingTransaction && (
           <div className="mt-3">
-            <TxStatusCard transaction={message.pendingTransaction} />
+            <TxStatusCard
+              transaction={message.pendingTransaction}
+              onStatusChange={
+                onPendingTransactionChange
+                  ? (patch) => onPendingTransactionChange(message.id, patch)
+                  : undefined
+              }
+            />
           </div>
         )}
         {showConnectCta && (

--- a/src/components/chat/TxStatusCard.test.tsx
+++ b/src/components/chat/TxStatusCard.test.tsx
@@ -102,4 +102,78 @@ describe('TxStatusCard', () => {
       expect(screen.getByText(/broadcasting/i)).toBeInTheDocument();
     });
   });
+
+  it('fires onStatusChange with submitted+signature after sendTransaction resolves', async () => {
+    wallet.sendTransaction.mockResolvedValue('sig-from-rpc-12345');
+    // First poll returns null — keeps state in broadcasting so we can assert the submitted callback fired pre-confirm.
+    connection.getSignatureStatuses.mockResolvedValue({ value: [null] });
+    connection.getBlockHeight.mockResolvedValue(50);
+    const onStatusChange = vi.fn();
+
+    render(<TxStatusCard transaction={baseTx} onStatusChange={onStatusChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /sign transaction/i }));
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledWith({
+        status: 'submitted',
+        signature: 'sig-from-rpc-12345',
+      });
+    });
+  });
+
+  it('fires onStatusChange with confirmed when poll succeeds', async () => {
+    wallet.sendTransaction.mockResolvedValue('sig-confirm-1');
+    connection.getSignatureStatuses.mockResolvedValue({
+      value: [{ confirmationStatus: 'confirmed', err: null }],
+    });
+    connection.getBlockHeight.mockResolvedValue(50);
+    const onStatusChange = vi.fn();
+
+    render(<TxStatusCard transaction={baseTx} onStatusChange={onStatusChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /sign transaction/i }));
+
+    // POLL_INTERVAL_MS is 2_000 — extend waitFor beyond the default 1s ceiling.
+    await waitFor(
+      () => {
+        expect(onStatusChange).toHaveBeenCalledWith({ status: 'confirmed' });
+      },
+      { timeout: 4_000 }
+    );
+  });
+
+  it('fires onStatusChange with failed+error when sendTransaction throws', async () => {
+    wallet.sendTransaction.mockRejectedValue(new Error('User rejected the request'));
+    const onStatusChange = vi.fn();
+
+    render(<TxStatusCard transaction={baseTx} onStatusChange={onStatusChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /sign transaction/i }));
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalled();
+    });
+    const lastCall = onStatusChange.mock.calls[onStatusChange.mock.calls.length - 1][0];
+    expect(lastCall.status).toBe('failed');
+    expect(typeof lastCall.error).toBe('string');
+    expect(lastCall.error.length).toBeGreaterThan(0);
+  });
+
+  it('does not throw when onStatusChange prop is omitted', async () => {
+    wallet.sendTransaction.mockResolvedValue('sig-orphan');
+    connection.getSignatureStatuses.mockResolvedValue({
+      value: [{ confirmationStatus: 'confirmed', err: null }],
+    });
+    connection.getBlockHeight.mockResolvedValue(50);
+
+    render(<TxStatusCard transaction={baseTx} />);
+    fireEvent.click(screen.getByRole('button', { name: /sign transaction/i }));
+
+    // No throw → confirmed UI eventually renders. POLL_INTERVAL_MS is 2_000 —
+    // extend waitFor beyond the default 1s ceiling.
+    await waitFor(
+      () => {
+        expect(screen.getByText(/confirmed/i)).toBeInTheDocument();
+      },
+      { timeout: 4_000 }
+    );
+  });
 });

--- a/src/components/chat/TxStatusCard.test.tsx
+++ b/src/components/chat/TxStatusCard.test.tsx
@@ -208,4 +208,85 @@ describe('TxStatusCard', () => {
       { timeout: 4_000 }
     );
   });
+
+  it('hydrates to broadcasting and resumes polling when status=submitted+signature', async () => {
+    connection.getSignatureStatuses.mockResolvedValue({
+      value: [{ confirmationStatus: 'confirmed', err: null }],
+    });
+    connection.getBlockHeight.mockResolvedValue(50);
+    const onStatusChange = vi.fn();
+
+    const tx: PendingTransaction = {
+      ...baseTx,
+      status: 'submitted',
+      signature: 'sig-resumed-on-mount',
+    };
+    render(<TxStatusCard transaction={tx} onStatusChange={onStatusChange} />);
+
+    // No "Sign Transaction" button — we're past needs-sign.
+    expect(screen.queryByRole('button', { name: /sign transaction/i })).not.toBeInTheDocument();
+
+    // Poll runs and resolves to confirmed.
+    // POLL_INTERVAL_MS is 2_000 — extend waitFor beyond the default 1s ceiling.
+    await waitFor(
+      () => {
+        expect(connection.getSignatureStatuses).toHaveBeenCalledWith(
+          ['sig-resumed-on-mount'],
+          expect.any(Object)
+        );
+      },
+      { timeout: 4_000 }
+    );
+    await waitFor(
+      () => {
+        expect(onStatusChange).toHaveBeenCalledWith({ status: 'confirmed' });
+      },
+      { timeout: 4_000 }
+    );
+    await waitFor(
+      () => {
+        expect(screen.getByText(/confirmed/i)).toBeInTheDocument();
+      },
+      { timeout: 4_000 }
+    );
+  });
+
+  it('falls back to needs-sign when status=submitted but signature is missing', () => {
+    const tx: PendingTransaction = {
+      ...baseTx,
+      status: 'submitted',
+      // signature deliberately omitted
+    };
+    render(<TxStatusCard transaction={tx} />);
+
+    // Defensive: missing signature → render Sign button so user can re-attempt.
+    expect(screen.getByRole('button', { name: /sign transaction/i })).toBeInTheDocument();
+    expect(connection.getSignatureStatuses).not.toHaveBeenCalled();
+  });
+
+  it('fires onStatusChange with failed when resumed poll detects blockhash-expired', async () => {
+    // Poll returns no signature info, then blockhash check fails.
+    connection.getSignatureStatuses.mockResolvedValue({ value: [null] });
+    connection.getBlockHeight.mockResolvedValue(99999);
+    const onStatusChange = vi.fn();
+
+    const tx: PendingTransaction = {
+      ...baseTx,
+      status: 'submitted',
+      signature: 'sig-stale',
+      lastValidBlockHeight: '100',
+    };
+    render(<TxStatusCard transaction={tx} onStatusChange={onStatusChange} />);
+
+    // POLL_INTERVAL_MS is 2_000 — extend waitFor beyond the default 1s ceiling.
+    await waitFor(
+      () => {
+        expect(onStatusChange).toHaveBeenCalled();
+      },
+      { timeout: 4_000 }
+    );
+    const lastCall = onStatusChange.mock.calls[onStatusChange.mock.calls.length - 1][0];
+    expect(lastCall.status).toBe('failed');
+    expect(lastCall.error).toMatch(/blockhash expired/i);
+  });
 });

--- a/src/components/chat/TxStatusCard.test.tsx
+++ b/src/components/chat/TxStatusCard.test.tsx
@@ -157,6 +157,38 @@ describe('TxStatusCard', () => {
     expect(lastCall.error.length).toBeGreaterThan(0);
   });
 
+  it('fires onStatusChange with failed+error when poll fails (blockhash-expired)', async () => {
+    wallet.sendTransaction.mockResolvedValue('sig-stale');
+    // Poll never sees the signature on-chain, and blockhash check fails.
+    connection.getSignatureStatuses.mockResolvedValue({ value: [null] });
+    connection.getBlockHeight.mockResolvedValue(99999); // > lastValidBlockHeight (100)
+    const onStatusChange = vi.fn();
+
+    render(
+      <TxStatusCard
+        transaction={{ ...baseTx, lastValidBlockHeight: '100' }}
+        onStatusChange={onStatusChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /sign transaction/i }));
+
+    // POLL_INTERVAL_MS is 2_000 — extend waitFor beyond the default 1s ceiling.
+    await waitFor(
+      () => {
+        const failedCalls = onStatusChange.mock.calls.filter(
+          ([patch]) => patch.status === 'failed'
+        );
+        expect(failedCalls.length).toBeGreaterThan(0);
+      },
+      { timeout: 4_000 }
+    );
+
+    const failedCall = onStatusChange.mock.calls.find(
+      ([patch]) => patch.status === 'failed'
+    )!;
+    expect(failedCall[0].error).toMatch(/blockhash expired/i);
+  });
+
   it('does not throw when onStatusChange prop is omitted', async () => {
     wallet.sendTransaction.mockResolvedValue('sig-orphan');
     connection.getSignatureStatuses.mockResolvedValue({

--- a/src/components/chat/TxStatusCard.tsx
+++ b/src/components/chat/TxStatusCard.tsx
@@ -74,6 +74,7 @@ export default function TxStatusCard({ transaction, onStatusChange }: Props) {
 
   const [phase, setPhase] = useState<Phase>(() => {
     if (transaction.status === 'confirmed' && transaction.signature) return 'confirmed';
+    if (transaction.status === 'submitted' && transaction.signature) return 'broadcasting';
     if (
       transaction.status === 'failed' ||
       transaction.status === 'cancelled' ||
@@ -95,6 +96,29 @@ export default function TxStatusCard({ transaction, onStatusChange }: Props) {
     },
     []
   );
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (transaction.status !== 'submitted' || !transaction.signature) return;
+    const sig = transaction.signature;
+    const lastValidBlockHeight = Number(transaction.lastValidBlockHeight);
+    let active = true;
+    pollSignatureStatus(connection, sig, lastValidBlockHeight).then((outcome) => {
+      if (!active || cancelRef.current) return;
+      if (outcome.status === 'confirmed') {
+        setPhase('confirmed');
+        onStatusChange?.({ status: 'confirmed' });
+      } else {
+        const classified = classifyWalletError(new Error(outcome.reason));
+        setError(classified);
+        setPhase('failed');
+        onStatusChange?.({ status: 'failed', error: outcome.reason });
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, []); // mount-only resume — never re-runs
 
   const handleSign = async () => {
     if (!connected || !publicKey) {

--- a/src/components/chat/TxStatusCard.tsx
+++ b/src/components/chat/TxStatusCard.tsx
@@ -12,6 +12,7 @@ type Phase = 'needs-sign' | 'signing' | 'broadcasting' | 'confirmed' | 'failed';
 
 interface Props {
   transaction: PendingTransaction;
+  onStatusChange?: (patch: Partial<PendingTransaction>) => void;
 }
 
 const POLL_INTERVAL_MS = 2_000;
@@ -67,7 +68,7 @@ async function pollSignatureStatus(
   return { status: 'failed', reason: 'Timed out waiting for confirmation.' };
 }
 
-export default function TxStatusCard({ transaction }: Props) {
+export default function TxStatusCard({ transaction, onStatusChange }: Props) {
   const { publicKey, connected, sendTransaction } = useWallet();
   const { connection } = useConnection();
 
@@ -112,6 +113,7 @@ export default function TxStatusCard({ transaction }: Props) {
       });
       setSignature(sig);
       setPhase('broadcasting');
+      onStatusChange?.({ status: 'submitted', signature: sig });
 
       const lastValidBlockHeight = Number(transaction.lastValidBlockHeight);
       const outcome = await pollSignatureStatus(connection, sig, lastValidBlockHeight);
@@ -119,10 +121,12 @@ export default function TxStatusCard({ transaction }: Props) {
 
       if (outcome.status === 'confirmed') {
         setPhase('confirmed');
+        onStatusChange?.({ status: 'confirmed' });
       } else {
         const classified = classifyWalletError(new Error(outcome.reason));
         setError(classified);
         setPhase('failed');
+        onStatusChange?.({ status: 'failed', error: outcome.reason });
       }
     } catch (err) {
       // eslint-disable-next-line no-console
@@ -130,6 +134,7 @@ export default function TxStatusCard({ transaction }: Props) {
       const classified = classifyWalletError(err);
       setError(classified);
       setPhase('failed');
+      onStatusChange?.({ status: 'failed', error: classified.message });
     }
   };
 

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -413,3 +413,186 @@ describe('useChat sendMessage streaming', () => {
     expect(result.current.isStreaming).toBe(false);
   });
 });
+
+describe('useChat updatePendingTransaction', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function seedConversationsWithPendingTx() {
+    const conv = {
+      id: 'c1',
+      title: 'deposit flow',
+      messages: [
+        { id: 'u1', role: 'user' as const, content: 'deposit 5 USDC', timestamp: 1 },
+        {
+          id: 'a1',
+          role: 'assistant' as const,
+          content: 'tx ready',
+          timestamp: 2,
+          pendingTransaction: {
+            action: 'deposit' as const,
+            protocol: 'Kamino' as const,
+            symbol: 'USDC',
+            amount: 5,
+            reserveAddress: 'D6q6wuQSrifJKZYpR1M8R4YawnLDtDsMmWM1NbBmgJ59',
+            mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            summary: 'Deposit 5 USDC',
+            base64Txn: 'AQAAAA==',
+            blockhash: 'bh-1',
+            lastValidBlockHeight: '300000000',
+            status: 'pending' as const,
+          },
+        },
+      ],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    localStorage.setItem('kami_conversations', JSON.stringify([conv]));
+    localStorage.setItem('kami_active_conversation', 'c1');
+  }
+
+  it('patches the target message pendingTransaction with shallow merge', () => {
+    seedConversationsWithPendingTx();
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.updatePendingTransaction('a1', {
+        status: 'submitted',
+        signature: 'sig-abc',
+      });
+    });
+
+    const msg = result.current.activeConversation.messages.find((m) => m.id === 'a1');
+    expect(msg?.pendingTransaction?.status).toBe('submitted');
+    expect(msg?.pendingTransaction?.signature).toBe('sig-abc');
+    // Untouched fields preserved:
+    expect(msg?.pendingTransaction?.base64Txn).toBe('AQAAAA==');
+    expect(msg?.pendingTransaction?.amount).toBe(5);
+  });
+
+  it('persists the update to localStorage via saveConversations', () => {
+    seedConversationsWithPendingTx();
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.updatePendingTransaction('a1', { status: 'confirmed' });
+    });
+
+    const raw = localStorage.getItem('kami_conversations');
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!);
+    const persistedMsg = parsed[0].messages.find((m: { id: string }) => m.id === 'a1');
+    expect(persistedMsg.pendingTransaction.status).toBe('confirmed');
+  });
+
+  it('is a no-op when messageId is not found', () => {
+    seedConversationsWithPendingTx();
+    const { result } = renderHook(() => useChat());
+    const before = JSON.stringify(result.current.conversations);
+
+    act(() => {
+      result.current.updatePendingTransaction('non-existent-id', {
+        status: 'confirmed',
+      });
+    });
+
+    const after = JSON.stringify(result.current.conversations);
+    expect(after).toBe(before);
+  });
+
+  it('is a no-op when the message exists but has no pendingTransaction', () => {
+    const conv = {
+      id: 'c1',
+      title: 'plain chat',
+      messages: [
+        { id: 'u1', role: 'user' as const, content: 'hi', timestamp: 1 },
+        { id: 'a1', role: 'assistant' as const, content: 'hello', timestamp: 2 },
+      ],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    localStorage.setItem('kami_conversations', JSON.stringify([conv]));
+    localStorage.setItem('kami_active_conversation', 'c1');
+
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.updatePendingTransaction('a1', { status: 'confirmed' });
+    });
+
+    const msg = result.current.activeConversation.messages.find((m) => m.id === 'a1');
+    expect(msg?.pendingTransaction).toBeUndefined();
+  });
+
+  it('does not mutate other messages when patching one', () => {
+    const conv = {
+      id: 'c1',
+      title: 'two txs',
+      messages: [
+        {
+          id: 'a1',
+          role: 'assistant' as const,
+          content: 'tx1',
+          timestamp: 1,
+          pendingTransaction: {
+            action: 'deposit' as const,
+            protocol: 'Kamino' as const,
+            symbol: 'USDC',
+            amount: 1,
+            reserveAddress: 'r1',
+            mint: 'm1',
+            summary: 's1',
+            base64Txn: 'AAAA',
+            blockhash: 'b1',
+            lastValidBlockHeight: '100',
+            status: 'pending' as const,
+          },
+        },
+        {
+          id: 'a2',
+          role: 'assistant' as const,
+          content: 'tx2',
+          timestamp: 2,
+          pendingTransaction: {
+            action: 'borrow' as const,
+            protocol: 'Kamino' as const,
+            symbol: 'SOL',
+            amount: 0.5,
+            reserveAddress: 'r2',
+            mint: 'm2',
+            summary: 's2',
+            base64Txn: 'BBBB',
+            blockhash: 'b2',
+            lastValidBlockHeight: '200',
+            status: 'pending' as const,
+          },
+        },
+      ],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    localStorage.setItem('kami_conversations', JSON.stringify([conv]));
+    localStorage.setItem('kami_active_conversation', 'c1');
+
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.updatePendingTransaction('a1', {
+        status: 'confirmed',
+        signature: 'sig-1',
+      });
+    });
+
+    const msg1 = result.current.activeConversation.messages.find((m) => m.id === 'a1');
+    const msg2 = result.current.activeConversation.messages.find((m) => m.id === 'a2');
+    expect(msg1?.pendingTransaction?.status).toBe('confirmed');
+    expect(msg1?.pendingTransaction?.signature).toBe('sig-1');
+    expect(msg2?.pendingTransaction?.status).toBe('pending');
+    expect(msg2?.pendingTransaction?.signature).toBeUndefined();
+  });
+});

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -596,3 +596,87 @@ describe('useChat updatePendingTransaction', () => {
     expect(msg2?.pendingTransaction?.signature).toBeUndefined();
   });
 });
+
+describe('useChat updatePendingTransaction stability', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('updatePendingTransaction reference is stable across re-renders', () => {
+    const { result } = renderHook(() => useChat());
+    const ref1 = result.current.updatePendingTransaction;
+
+    act(() => {
+      result.current.newConversation();
+    });
+
+    const ref2 = result.current.updatePendingTransaction;
+    expect(ref1).toBe(ref2);
+  });
+
+  it('a captured updatePendingTransaction reference reads latest conversations on call', () => {
+    const conv = {
+      id: 'c1',
+      title: 'deposit',
+      messages: [
+        {
+          id: 'a1',
+          role: 'assistant' as const,
+          content: 'tx',
+          timestamp: 1,
+          pendingTransaction: {
+            action: 'deposit' as const,
+            protocol: 'Kamino' as const,
+            symbol: 'USDC',
+            amount: 5,
+            reserveAddress: 'r1',
+            mint: 'm1',
+            summary: 's1',
+            base64Txn: 'AAAA',
+            blockhash: 'b1',
+            lastValidBlockHeight: '100',
+            status: 'submitted' as const,
+            signature: 'sig-1',
+          },
+        },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    localStorage.setItem('kami_conversations', JSON.stringify([conv]));
+    localStorage.setItem('kami_active_conversation', 'c1');
+
+    const { result } = renderHook(() => useChat());
+
+    // Capture the mount-time reference (simulating what TxStatusCard's resume useEffect does).
+    const capturedUpdate = result.current.updatePendingTransaction;
+
+    // Now mutate state via a different code path — this would invalidate a stale-snapshot closure.
+    act(() => {
+      result.current.newConversation();
+    });
+
+    // Verify state change happened: 2 conversations now.
+    expect(result.current.conversations.length).toBe(2);
+
+    // Call the captured (mount-time) reference and patch the original message.
+    act(() => {
+      capturedUpdate('a1', { status: 'confirmed' });
+    });
+
+    // BOTH the new conversation AND the patched message must survive.
+    expect(result.current.conversations.length).toBe(2); // new conversation NOT wiped
+    const c1 = result.current.conversations.find((c) => c.id === 'c1');
+    expect(c1?.messages[0].pendingTransaction?.status).toBe('confirmed');
+
+    // localStorage agrees.
+    const stored = JSON.parse(localStorage.getItem('kami_conversations')!);
+    expect(stored.length).toBe(2);
+    const storedC1 = stored.find((c: { id: string }) => c.id === 'c1');
+    expect(storedC1.messages[0].pendingTransaction.status).toBe('confirmed');
+  });
+});

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -136,6 +136,21 @@ export function useChat() {
     [conversations, persist]
   );
 
+  const updatePendingTransaction = useCallback(
+    (messageId: string, patch: Partial<PendingTransaction>) => {
+      const updated = conversations.map((c) => ({
+        ...c,
+        messages: c.messages.map((m) =>
+          m.id === messageId && m.pendingTransaction
+            ? { ...m, pendingTransaction: { ...m.pendingTransaction, ...patch } }
+            : m
+        ),
+      }));
+      persist(updated);
+    },
+    [conversations, persist]
+  );
+
   const sendMessage = useCallback(
     async (content: string, walletAddress?: string | null) => {
       if (!content.trim() || isStreaming) return;
@@ -333,5 +348,6 @@ export function useChat() {
     deleteConversation,
     clearAllConversations,
     renameConversation,
+    updatePendingTransaction,
   };
 }

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import type { ChatMessage, Conversation, PendingTransaction, ToolCallRecord } from '../types';
 
 const BUILD_TOOL_NAMES = new Set(['buildDeposit', 'buildBorrow', 'buildWithdraw', 'buildRepay']);
@@ -83,6 +83,15 @@ export function useChat() {
     saveConversations(updated);
   }, []);
 
+  // Mirror conversations into a ref so callbacks captured by long-lived async
+  // contexts (e.g. TxStatusCard's resume useEffect) read current state when
+  // they fire, not the snapshot at capture time. Prevents data-loss race
+  // where a stale-closure persist would overwrite intervening user activity.
+  const conversationsRef = useRef(conversations);
+  useEffect(() => {
+    conversationsRef.current = conversations;
+  }, [conversations]);
+
   const switchConversation = useCallback((id: string) => {
     abortRef.current?.abort();
     setActiveId(id);
@@ -138,7 +147,7 @@ export function useChat() {
 
   const updatePendingTransaction = useCallback(
     (messageId: string, patch: Partial<PendingTransaction>) => {
-      const updated = conversations.map((c) => ({
+      const updated = conversationsRef.current.map((c) => ({
         ...c,
         messages: c.messages.map((m) =>
           m.id === messageId && m.pendingTransaction
@@ -148,7 +157,7 @@ export function useChat() {
       }));
       persist(updated);
     },
-    [conversations, persist]
+    [persist]
   );
 
   const sendMessage = useCallback(


### PR DESCRIPTION
## Summary

Fixes a silent UX bug discovered during Day 21 financial QA: confirmed-on-chain Kamino transactions reverted to \`'needs-sign'\` state on page reload, exposing users to duplicate-sign risk during the polling window.

- **Root cause:** \`TxStatusCard\` kept \`phase\` and \`signature\` in component-local \`useState\`. \`useChat.ts\` wrote \`pendingTransaction = { ...output.data, status: 'pending' }\` once when the build* tool result arrived, then never updated as the card transitioned through signing → broadcasting → confirmed/failed. After reload, the persisted \`status\` was still \`'pending'\`, so the phase initializer fell through to \`'needs-sign'\`.
- **Fix:** new \`useChat.updatePendingTransaction(messageId, patch)\` method, optional \`onStatusChange\` callback on TxStatusCard, mount-only resume \`useEffect\` that re-kicks \`pollSignatureStatus\` when persisted state is \`'submitted' + signature\`. Wired through \`MessageBubble\` + \`App.tsx\`. Zero schema changes — \`PendingTransaction.status\` enum already supported the lifecycle.
- **Bonus fix:** stale-closure data-loss race in \`useChat\`. Caught during round-1 review of Task 4 by the cluster reviewer. The resume \`useEffect\`'s mount-time captured callback would persist a stale \`conversations\` snapshot when the poll resolved 2-120s later, silently wiping any messages or conversations created during the polling window. Closed via \`conversationsRef\` mirror pattern.

## Architecture

End-to-end persistence chain now closed:

\`\`\`
TxStatusCard transition → onStatusChange?(patch) → MessageBubble closure
  → onPendingTransactionChange(message.id, patch) → useChat.updatePendingTransaction
  → conversationsRef.current.map(...) → persist → saveConversations
  → reload reads back via TxStatusCard's mount-time resume useEffect
\`\`\`

Specs + plan committed to the branch:
- \`docs/superpowers/specs/2026-05-01-txstatuscard-reload-hydration-design.md\`
- \`docs/superpowers/plans/2026-05-01-txstatuscard-reload-hydration-implementation.md\`

## Reload paths

| Persisted state at unload | Initial phase on remount | Behavior |
|---|---|---|
| \`status='pending'\`, no signature | \`needs-sign\` | Show Sign button (existing). |
| \`status='submitted'\`, signature present | **\`broadcasting\`** (NEW) | Resume polling; closes duplicate-sign window. |
| \`status='confirmed'\`, signature present | \`confirmed\` (existing) | Solscan link, no action. |
| \`status='failed'\`, error present | \`failed\` (existing) | Error + Retry button. |

## Test plan

- [x] \`pnpm exec tsc --noEmit\` (client typecheck) — silent
- [x] \`pnpm exec tsc -p server/tsconfig.json --noEmit\` (server typecheck) — silent
- [x] \`pnpm exec tsc -b\` (project mode, matches Vercel) — silent
- [x] \`pnpm test:run\` — **287/287 across 39 files** (was 270, +17)
- [x] \`pnpm build\` — clean (main bundle 634.33 kB, +0.6 kB)
- [ ] Production smoke after merge: reload kami.rectorspace.com mid-deposit and verify the broadcasting state resumes instead of reverting to Sign Transaction

## Test count delta

270 → **287** (+17 across 3 existing test files; no new test files):
- \`src/hooks/useChat.test.ts\`: +5 (updatePendingTransaction core) + 2 (stability + stale-closure-reads-current) = +7
- \`src/components/chat/TxStatusCard.test.tsx\`: +4 (callback firing) + 1 (round-1 fix: poll-failed in handleSign) + 3 (hydration on mount) = +8
- \`src/components/chat/MessageBubble.test.tsx\`: +2 (prop forwarding)

## Review history

5 implementer subagent dispatches + 5 spec compliance reviews + 5 code quality reviews (opus) + 1 final cluster review (opus). All SHIP IT after their respective fix loops. 0 Critical / 0 Important across the entire branch. The Task 5 stale-closure fix in particular was caught pre-merge — it would have been very easy to ship without \`conversationsRef\` and never see the bug in CI because tests don't typically simulate cross-render captured closures.