### PR TITLE
fix(landing): wrap long ToolCell hints + sync test count to 287

### DIFF
--- a/src/components/landing/ToolCell.tsx
+++ b/src/components/landing/ToolCell.tsx
@@ -34,7 +34,7 @@ export default function ToolCell({ tool, delay }: Props) {
       <p className="font-sans text-sm text-kami-cream/80 leading-relaxed flex-1">
         {tool.description}
       </p>
-      <div className="font-mono text-[11px] text-kami-creamMuted px-3 py-2 rounded-lg border border-kami-cellBorder bg-kami-sepiaBg/40 group-hover:border-kami-amber/40 transition-colors">
+      <div className="font-mono text-[11px] text-kami-creamMuted px-3 py-2 rounded-lg border border-kami-cellBorder bg-kami-sepiaBg/40 group-hover:border-kami-amber/40 transition-colors break-all">
         {tool.hint}
       </div>
     </BentoCell>

--- a/src/lib/landing-content.ts
+++ b/src/lib/landing-content.ts
@@ -9,7 +9,7 @@ export interface LandingStat {
 
 export const LANDING_STATS: ReadonlyArray<LandingStat> = [
   { key: 'sys.tools_loaded', value: '7 active', highlight: true },
-  { key: 'ci.tests_passing', value: '270 suite', highlight: false },
+  { key: 'ci.tests_passing', value: '287 suite', highlight: false },
   { key: 'net.roundtrips', value: '3 mainnet', highlight: false },
   { key: 'sys.genesis', value: '2026-04-19', highlight: false },
 ];


### PR DESCRIPTION
## Summary
- **ToolCell hint pill:** add `break-all` so the 44-char identifier `→ Obligation.simulateBorrowAndWithdrawAction` wraps inside the rounded border instead of clipping past it at `lg:col-span-3` (visible bleeding text in the middle bento row).
- **LANDING_STATS:** bump `ci.tests_passing` 270 → 287 (matches current suite count after PR #52 reload-hydration tests).

Both surfaces are pre-connect and the first thing a bounty judge sees. Caught via screenshot review before demo recording.

## Test plan
- [x] `pnpm test:run` — 287/287 across 39 files
- [x] `pnpm exec tsc --noEmit` — silent
- [ ] Post-deploy: hard-reload https://kami.rectorspace.com, confirm middle row hints wrap cleanly inside their pills + SysMetrics shows `287 suite`