### PR TITLE
fix(TxStatusCard): skipPreflight: true to bypass Helius blockhash race

### DIFF
--- a/src/components/chat/TxStatusCard.test.tsx
+++ b/src/components/chat/TxStatusCard.test.tsx
@@ -356,7 +356,7 @@ describe('TxStatusCard', () => {
     // The exact bytes from signTransaction must be passed to sendRawTransaction.
     expect(connection.sendRawTransaction).toHaveBeenCalledWith(
       signedBytes,
-      expect.objectContaining({ skipPreflight: false, maxRetries: 3 })
+      expect.objectContaining({ skipPreflight: true, maxRetries: 3 })
     );
   });
 

--- a/src/components/chat/TxStatusCard.tsx
+++ b/src/components/chat/TxStatusCard.tsx
@@ -149,10 +149,13 @@ export default function TxStatusCard({ transaction, onStatusChange }: Props) {
 
       // Step 2: WE broadcast through OUR /api/rpc → Helius. Same RPC as preflight,
       // structured SendTransactionError on failure (with .logs we can parse).
+      // skipPreflight: true bypasses Helius's racy second-simulation that intermittently
+      // returns "Blockhash not found" when load-balanced backends differ between the node
+      // that issued the blockhash (server preflight) and the node that receives the
+      // broadcast. Server-side preflightSimulate (kamino.ts) already validated tx logic.
       const sig = await connection.sendRawTransaction(signed.serialize(), {
-        skipPreflight: false,
+        skipPreflight: true,
         maxRetries: 3,
-        preflightCommitment: 'confirmed',
       });
 
       setSignature(sig);


### PR DESCRIPTION
## Summary
- Switches \`connection.sendRawTransaction\` to \`skipPreflight: true\` so Helius's racy second-simulation no longer rejects fresh broadcasts with \"Blockhash not found\".

## Why
Three consecutive live tests post-Cluster-H deploy (PR #54) failed identically:

\`\`\`
[Kami] sign or broadcast failed N1: Simulation failed.
Message: Transaction simulation failed: Blockhash not found.
\`\`\`

Root cause: Helius internal load-balancing routes the freshly-fetched blockhash to a different backend node than the one that issued it during server-side preflight. The second simulation (Helius preflight on broadcast) intermittently rejects valid txns this way.

Server-side \`preflightSimulate\` (Cluster H Task 3) already validates tx logic with structured \`errorCode\`/\`context\`. The Helius double-preflight was redundant — and racy enough to be **bounty-blocking** (without it, Shot 5/6/7/8 of the demo recording can't broadcast).

## Trade-off accepted
- ✅ Pro: bypass the racy second-preflight; broadcasts go through Helius's relay layer
- 🟡 Con: if blockhash is genuinely stale by validator-receive time, broadcast wastes ~5000 lamports (~\$0.0008)
- ✅ Server preflight catches all tx-logic errors → this is purely a tx-fee risk on near-impossible edge

## Test plan
- [x] 311/311 tests pass (test assertion in TxStatusCard.test.tsx flipped from \`skipPreflight: false\` to \`true\`)
- [x] Both typechecks silent
- [ ] Post-deploy live smoke: re-test the same repay flow that failed 3× pre-fix → expect broadcast succeeds + confirmed on mainnet