### PR TITLE
feat(landing): demo video band above bento grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage/
 # QA reports (gitignored — use --commit to publish)
 .qa/
 .superpowers/
+.env*.local

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -6,10 +6,13 @@ import LatestTxCell from './landing/LatestTxCell';
 import ToolCell from './landing/ToolCell';
 import PipelineCell from './landing/PipelineCell';
 import SponsorStrip from './landing/SponsorStrip';
+import DemoVideoBand from './landing/DemoVideoBand';
 import { TOOL_CELLS } from '../lib/landing-content';
 
 const SOLFLARE_WALLET_NAME = 'Solflare';
 const SOLFLARE_INSTALL_URL = 'https://solflare.com/download';
+const DEMO_VIDEO_URL =
+  'https://aheyudueboveptjv.public.blob.vercel-storage.com/demo/kami-walkthrough.mp4';
 
 export default function EmptyState() {
   const { connected, connecting, wallets, select } = useWallet();
@@ -58,6 +61,8 @@ export default function EmptyState() {
             />
           </span>
         </div>
+
+        <DemoVideoBand videoSrc={DEMO_VIDEO_URL} />
 
         <div className="grid grid-cols-12 gap-3 lg:gap-4">
           <HeroCell

--- a/src/components/landing/DemoVideoBand.test.tsx
+++ b/src/components/landing/DemoVideoBand.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import DemoVideoBand from './DemoVideoBand';
+
+const TEST_URL = 'https://example.com/test-video.mp4';
+
+describe('DemoVideoBand', () => {
+  it('renders a section labeled for assistive tech', () => {
+    render(<DemoVideoBand videoSrc={TEST_URL} />);
+    expect(screen.getByRole('region', { name: /kami demo video/i })).toBeInTheDocument();
+  });
+
+  it('renders the caption noting the demo is silent', () => {
+    render(<DemoVideoBand videoSrc={TEST_URL} />);
+    expect(screen.getByText(/3 min walkthrough/i)).toBeInTheDocument();
+    expect(screen.getByText(/silent/i)).toBeInTheDocument();
+  });
+
+  it('renders a video element with the provided source', () => {
+    const { container } = render(<DemoVideoBand videoSrc={TEST_URL} />);
+    const video = container.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video?.getAttribute('src')).toBe(TEST_URL);
+  });
+
+  it('renders native HTML5 controls on the video', () => {
+    const { container } = render(<DemoVideoBand videoSrc={TEST_URL} />);
+    const video = container.querySelector('video');
+    expect(video?.hasAttribute('controls')).toBe(true);
+  });
+
+  it('uses preload="metadata" so the full file is not downloaded eagerly', () => {
+    const { container } = render(<DemoVideoBand videoSrc={TEST_URL} />);
+    const video = container.querySelector('video');
+    expect(video?.getAttribute('preload')).toBe('metadata');
+  });
+
+  it('sets playsInline so iOS plays inline instead of fullscreen-takeover', () => {
+    const { container } = render(<DemoVideoBand videoSrc={TEST_URL} />);
+    const video = container.querySelector('video');
+    expect(video?.hasAttribute('playsinline')).toBe(true);
+  });
+
+  it('preserves the recording aspect ratio via the wrapper container', () => {
+    const { container } = render(<DemoVideoBand videoSrc={TEST_URL} />);
+    const wrapper = container.querySelector('section > div');
+    expect(wrapper?.className).toMatch(/aspect-\[1280\/1026\]/);
+  });
+});

--- a/src/components/landing/DemoVideoBand.tsx
+++ b/src/components/landing/DemoVideoBand.tsx
@@ -1,0 +1,25 @@
+interface Props {
+  videoSrc: string;
+}
+
+export default function DemoVideoBand({ videoSrc }: Props) {
+  return (
+    <section
+      aria-label="Kami demo video"
+      className="mb-8 lg:mb-12 flex flex-col items-center gap-3"
+    >
+      <div className="w-full max-w-4xl aspect-[1280/1026] rounded-2xl overflow-hidden border border-kami-cellBorder bg-black shadow-2xl">
+        <video
+          src={videoSrc}
+          controls
+          preload="metadata"
+          playsInline
+          className="w-full h-full"
+        />
+      </div>
+      <p className="font-mono text-xs text-kami-creamMuted uppercase tracking-wider">
+        [demo · 3 min walkthrough · silent]
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Embeds a 3-min walkthrough video (9.6 MB, silent, 1280×1026 @ 30fps) on the pre-connect bento landing page, above the bento grid.
- Hosted on Vercel Blob (`kami-demo` store created this session) — public CDN URL, 30-day cache, range-request supported for scrubbing.
- Native HTML5 video controls handle playback + fullscreen; no custom modal needed.
- `preload="metadata"` so the file is not pulled until a judge clicks play.
- Caption `[demo · 3 min walkthrough · silent]` sets the silent-by-design expectation upfront.

## Why

The Eitherway-Kamino bounty deadline is 2026-05-12. Judges hit kami.rectorspace.com without a wallet; the bento landing previously required them to imagine what Kami does. This puts the demo *first*, in the "above the fold" hero position — the video IS the elevator pitch.

This complements the bento grid (HeroCell + SysMetrics + LatestTx + Tools + Pipeline + SponsorStrip) which now serves as the proof-of-depth layer below.

## Implementation

- New: `src/components/landing/DemoVideoBand.tsx` (22 lines) — `<section>` with aria-label, fixed aspect-ratio wrapper, native `<video>` with `controls`, `preload="metadata"`, `playsInline`.
- New: `src/components/landing/DemoVideoBand.test.tsx` (+7 tests covering aria, caption, src, controls, preload, playsInline, aspect-ratio).
- Modified: `src/components/EmptyState.tsx` (+1 import, +1 `DEMO_VIDEO_URL` module constant, +1 render between status header and bento grid). No state added.
- Modified: `.gitignore` (defensive `.env*.local` pattern, auto-added by Vercel CLI when linking the new Blob store — `.env.local` now carries `BLOB_READ_WRITE_TOKEN` and must never be committed).

## Verification

- `pnpm test:run` → 318 passed (was 311, +7 from DemoVideoBand).
- `pnpm exec tsc --noEmit` → silent.
- `pnpm exec tsc -p server/tsconfig.json --noEmit` → silent.
- `pnpm exec tsc -b` → silent.
- `pnpm build` → clean. Main bundle 635.99 kB (+1 kB from main).
- Visually verified at desktop viewport (1700px) — video band centers at max-w-4xl (896×718), bento intact below.
- CSS analysis confirms responsive behavior: `w-full max-w-4xl aspect-[1280/1026]` scales from 343×275 on iPhone SE up to 896×718 on lg+.

## Test plan

- [ ] Refresh https://kami.rectorspace.com after merge → video band renders above bento.
- [ ] Click play → 3-min walkthrough plays inline; native fullscreen button works.
- [ ] On mobile (iPhone Safari): video scales to viewport width with preserved aspect ratio; controls usable.
- [ ] DevTools Network tab: video file is NOT downloaded on initial page load (only metadata).