### PR TITLE
fix(landing): add poster to demo video so first frame shows

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -13,6 +13,8 @@ const SOLFLARE_WALLET_NAME = 'Solflare';
 const SOLFLARE_INSTALL_URL = 'https://solflare.com/download';
 const DEMO_VIDEO_URL =
   'https://aheyudueboveptjv.public.blob.vercel-storage.com/demo/kami-walkthrough.mp4';
+const DEMO_POSTER_URL =
+  'https://aheyudueboveptjv.public.blob.vercel-storage.com/demo/kami-walkthrough-poster.jpg';
 
 export default function EmptyState() {
   const { connected, connecting, wallets, select } = useWallet();
@@ -62,7 +64,7 @@ export default function EmptyState() {
           </span>
         </div>
 
-        <DemoVideoBand videoSrc={DEMO_VIDEO_URL} />
+        <DemoVideoBand videoSrc={DEMO_VIDEO_URL} posterSrc={DEMO_POSTER_URL} />
 
         <div className="grid grid-cols-12 gap-3 lg:gap-4">
           <HeroCell

--- a/src/components/landing/DemoVideoBand.test.tsx
+++ b/src/components/landing/DemoVideoBand.test.tsx
@@ -41,6 +41,19 @@ describe('DemoVideoBand', () => {
     expect(video?.hasAttribute('playsinline')).toBe(true);
   });
 
+  it('renders the poster attribute when posterSrc is provided', () => {
+    const POSTER = 'https://example.com/poster.jpg';
+    const { container } = render(<DemoVideoBand videoSrc={TEST_URL} posterSrc={POSTER} />);
+    const video = container.querySelector('video');
+    expect(video?.getAttribute('poster')).toBe(POSTER);
+  });
+
+  it('omits the poster attribute when posterSrc is not provided', () => {
+    const { container } = render(<DemoVideoBand videoSrc={TEST_URL} />);
+    const video = container.querySelector('video');
+    expect(video?.hasAttribute('poster')).toBe(false);
+  });
+
   it('preserves the recording aspect ratio via the wrapper container', () => {
     const { container } = render(<DemoVideoBand videoSrc={TEST_URL} />);
     const wrapper = container.querySelector('section > div');

--- a/src/components/landing/DemoVideoBand.tsx
+++ b/src/components/landing/DemoVideoBand.tsx
@@ -1,8 +1,9 @@
 interface Props {
   videoSrc: string;
+  posterSrc?: string;
 }
 
-export default function DemoVideoBand({ videoSrc }: Props) {
+export default function DemoVideoBand({ videoSrc, posterSrc }: Props) {
   return (
     <section
       aria-label="Kami demo video"
@@ -11,6 +12,7 @@ export default function DemoVideoBand({ videoSrc }: Props) {
       <div className="w-full max-w-4xl aspect-[1280/1026] rounded-2xl overflow-hidden border border-kami-cellBorder bg-black shadow-2xl">
         <video
           src={videoSrc}
+          poster={posterSrc}
           controls
           preload="metadata"
           playsInline


### PR DESCRIPTION
## Symptom

On production after PR #56 merged, the demo video band rendered as a black frame with native controls visible (play/0:00/mute/fullscreen) — but no first-frame thumbnail. Judges would have to click play to see what Kami does.

## Root cause

`preload="metadata"` loads only video dimensions + duration, not pixel data. With no `poster=` attribute, the player shows the default browser background (black) until playback starts.

## Fix

Generated a representative still frame from the demo (Kami's `findYield` tool call rendering the Kamino Main Market USDC table with risk chips and structured analysis) using ffmpeg at the 0:45 mark, uploaded to the same `kami-demo` Vercel Blob store, and wired it through `DemoVideoBand` as a new optional `posterSrc` prop.

## Files

- `src/components/landing/DemoVideoBand.tsx` — added optional `posterSrc` prop, passed to `<video poster=...>`.
- `src/components/landing/DemoVideoBand.test.tsx` — +2 tests (renders poster when provided, omits when absent).
- `src/components/EmptyState.tsx` — added `DEMO_POSTER_URL` constant, passed to `<DemoVideoBand>`.

## Verification

- `pnpm test:run` → 320 passed (was 318, +2 poster tests).
- `pnpm exec tsc --noEmit` → silent.
- `pnpm exec tsc -p server/tsconfig.json --noEmit` → silent.

## Test plan

- [ ] After merge → refresh https://kami.rectorspace.com → video band shows the findYield poster (NOT a black frame).
- [ ] Click play → 3-min walkthrough begins from the first second.
- [ ] DevTools Network tab → poster (~73 KB JPEG) loads on initial render; video file still NOT downloaded until play.