### PR TITLE
fix(csp): allow Vercel Blob domain for poster + video

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -30,7 +30,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob:; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https://*.public.blob.vercel-storage.com; media-src 'self' https://*.public.blob.vercel-storage.com; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
         }
       ]
     }


### PR DESCRIPTION
## Symptom

Production landing page's demo video band shows a black frame; DevTools console flags two CSP violations:

\`\`\`
Loading the image 'https://aheyudueboveptjv.public.blob.vercel-storage.com/...'
  violates the following Content Security Policy directive:
  "img-src 'self' data: blob:". The action has been blocked.

Loading media from 'https://aheyudueboveptjv.public.blob.vercel-storage.com/...'
  violates the following Content Security Policy directive:
  "default-src 'self'". Note that 'media-src' was not explicitly set,
  so 'default-src' is used as a fallback. The action has been blocked.
\`\`\`

## Root cause

\`vercel.json\` CSP allowlist:
- \`img-src\` only permitted \`'self' data: blob:\` — Vercel Blob's HTTPS subdomain was not allowed
- No \`media-src\` directive — falls back to \`default-src 'self'\` which blocks all cross-origin media

Both the poster JPG (PR #57) and the demo video (PR #56) live on \`aheyudueboveptjv.public.blob.vercel-storage.com\` (kami-demo Blob store).

## Fix

Add the public Vercel Blob host to both directives:
- \`img-src 'self' data: blob: https://*.public.blob.vercel-storage.com\`
- \`media-src 'self' https://*.public.blob.vercel-storage.com\` (new directive)

Wildcard the public-blob subdomain so future store rotations don't require another CSP edit. The wildcard is constrained to the \`*.public.blob.vercel-storage.com\` host pattern owned and operated by Vercel.

## Verification

- \`git diff vercel.json\` → single-line CSP value change, both new tokens placed alongside existing ones in the same directive groups.
- No code or test changes; CSP is enforced by the Vercel edge, not testable locally.

## Test plan

- [ ] After merge → Vercel auto-deploys (~1-2 min) → refresh https://kami.rectorspace.com.
- [ ] Hard reload (Cmd+Shift+R) to bust the CSP-enforced 304 cache for index.html.
- [ ] Video band shows the findYield poster (no longer black).
- [ ] Click play → video begins streaming.
- [ ] DevTools console → no CSP violations remain.