### PR TITLE
feat(pitch): add /pitch route — judge-targeted submission deck

### DIFF
--- a/public/architecture.svg
+++ b/public/architecture.svg
@@ -1,0 +1,149 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" role="img" aria-label="Kami architecture diagram">
+  <defs>
+    <style>
+      .bg { fill: #0a0a0f; }
+      .panel { fill: #12121a; stroke: #1e1e2e; stroke-width: 1.5; }
+      .panel-accent { fill: #12121a; stroke: #7c3aed; stroke-width: 1.75; }
+      .panel-success { fill: #12121a; stroke: #10b981; stroke-width: 1.75; }
+      .panel-muted { fill: #0f0f16; stroke: #1e1e2e; stroke-width: 1.25; }
+      .label-strong { fill: #ffffff; font: 600 17px 'Inter', system-ui, sans-serif; }
+      .label { fill: #e2e8f0; font: 500 14px 'Inter', system-ui, sans-serif; }
+      .label-sm { fill: #94a3b8; font: 400 12px 'Inter', system-ui, sans-serif; }
+      .label-mono { fill: #c4b5fd; font: 500 12.5px 'JetBrains Mono', ui-monospace, monospace; }
+      .label-mono-green { fill: #6ee7b7; font: 500 12.5px 'JetBrains Mono', ui-monospace, monospace; }
+      .title { fill: #ffffff; font: 700 22px 'Inter', system-ui, sans-serif; }
+      .stage { fill: #7c3aed; font: 700 11px 'Inter', system-ui, sans-serif; letter-spacing: 1.5px; }
+      .stage-green { fill: #10b981; font: 700 11px 'Inter', system-ui, sans-serif; letter-spacing: 1.5px; }
+      .flow-arrow { stroke: #7c3aed; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+      .flow-arrow-return { stroke: #475569; stroke-width: 1.5; stroke-dasharray: 4 4; fill: none; marker-end: url(#arrow-muted); }
+      .annotation { fill: #64748b; font: 400 11px 'Inter', system-ui, sans-serif; font-style: italic; }
+    </style>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#7c3aed"/>
+    </marker>
+    <marker id="arrow-muted" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="1200" height="720"/>
+
+  <text class="title" x="600" y="40" text-anchor="middle">Kami — AI Co-Pilot for Kamino DeFi</text>
+  <text class="label-sm" x="600" y="62" text-anchor="middle">Plain English → signed mainnet tx, end-to-end on Solana</text>
+
+  <!-- STAGE LABELS -->
+  <text class="stage" x="150" y="110" text-anchor="middle">CLIENT</text>
+  <text class="stage" x="450" y="110" text-anchor="middle">VERCEL EDGE</text>
+  <text class="stage" x="750" y="110" text-anchor="middle">DEFI LOGIC</text>
+  <text class="stage-green" x="1050" y="110" text-anchor="middle">SOLANA MAINNET</text>
+
+  <!-- CLIENT: Kami UI -->
+  <rect class="panel-accent" x="50" y="135" width="200" height="140" rx="10"/>
+  <text class="label-strong" x="150" y="170" text-anchor="middle">Kami UI</text>
+  <text class="label-sm" x="150" y="192" text-anchor="middle">Vite · React 18 · TS</text>
+  <text class="label-sm" x="150" y="210" text-anchor="middle">Tailwind · Lucide</text>
+  <line x1="75" y1="225" x2="225" y2="225" stroke="#1e1e2e" stroke-width="1"/>
+  <text class="label-mono" x="150" y="245" text-anchor="middle">streamText</text>
+  <text class="label-mono" x="150" y="262" text-anchor="middle">AI SDK fullStream</text>
+
+  <!-- CLIENT: Wallet Standard -->
+  <rect class="panel" x="50" y="295" width="200" height="110" rx="10"/>
+  <text class="label-strong" x="150" y="328" text-anchor="middle">Wallet Standard</text>
+  <text class="label-sm" x="150" y="350" text-anchor="middle">Solflare (featured)</text>
+  <text class="label-sm" x="150" y="368" text-anchor="middle">Phantom · Backpack · …</text>
+  <text class="label-sm" x="150" y="390" text-anchor="middle">signs tx · submits</text>
+
+  <!-- VERCEL EDGE: /api/chat -->
+  <rect class="panel-accent" x="350" y="135" width="200" height="140" rx="10"/>
+  <text class="label-strong" x="450" y="170" text-anchor="middle">/api/chat</text>
+  <text class="label-sm" x="450" y="192" text-anchor="middle">Node-style Fn</text>
+  <text class="label-sm" x="450" y="210" text-anchor="middle">zod-validated body</text>
+  <line x1="375" y1="225" x2="525" y2="225" stroke="#1e1e2e" stroke-width="1"/>
+  <text class="label-mono" x="450" y="245" text-anchor="middle">OpenRouter LLM</text>
+  <text class="label-mono" x="450" y="262" text-anchor="middle">claude-sonnet-4.6</text>
+
+  <!-- VERCEL EDGE: /api/rpc -->
+  <rect class="panel-accent" x="350" y="295" width="200" height="130" rx="10"/>
+  <text class="label-strong" x="450" y="330" text-anchor="middle">/api/rpc</text>
+  <text class="label-sm" x="450" y="352" text-anchor="middle">same-origin only</text>
+  <text class="label-sm" x="450" y="370" text-anchor="middle">15-method denylist</text>
+  <text class="label-sm" x="450" y="388" text-anchor="middle">64 KiB body cap</text>
+  <text class="label-mono" x="450" y="410" text-anchor="middle">→ Helius RPC</text>
+
+  <!-- DEFI LOGIC: tools -->
+  <rect class="panel-accent" x="650" y="135" width="200" height="290" rx="10"/>
+  <text class="label-strong" x="750" y="170" text-anchor="middle">7 Tools</text>
+  <text class="label-sm" x="750" y="190" text-anchor="middle">(AI SDK tool() defs)</text>
+  <line x1="675" y1="205" x2="825" y2="205" stroke="#1e1e2e" stroke-width="1"/>
+  <text class="label-mono" x="750" y="225" text-anchor="middle">getPortfolio</text>
+  <text class="label-mono" x="750" y="243" text-anchor="middle">findYield</text>
+  <text class="label-mono" x="750" y="261" text-anchor="middle">simulateHealth</text>
+  <line x1="675" y1="275" x2="825" y2="275" stroke="#1e1e2e" stroke-width="1"/>
+  <text class="label-mono" x="750" y="295" text-anchor="middle">buildDeposit</text>
+  <text class="label-mono" x="750" y="313" text-anchor="middle">buildBorrow</text>
+  <text class="label-mono" x="750" y="331" text-anchor="middle">buildRepay</text>
+  <text class="label-mono" x="750" y="349" text-anchor="middle">buildWithdraw</text>
+  <line x1="675" y1="363" x2="825" y2="363" stroke="#1e1e2e" stroke-width="1"/>
+  <text class="label-sm" x="750" y="383" text-anchor="middle">klend-sdk 7.3 · @solana/kit v2</text>
+  <text class="label-sm" x="750" y="401" text-anchor="middle">createNoopSigner</text>
+  <text class="label-sm" x="750" y="418" text-anchor="middle">compileTransaction</text>
+
+  <!-- SOLANA: Kamino Main Market -->
+  <rect class="panel-success" x="950" y="135" width="200" height="140" rx="10"/>
+  <text class="label-strong" x="1050" y="170" text-anchor="middle">Kamino</text>
+  <text class="label-strong" x="1050" y="192" text-anchor="middle">Main Market</text>
+  <line x1="975" y1="207" x2="1125" y2="207" stroke="#1e1e2e" stroke-width="1"/>
+  <text class="label-mono-green" x="1050" y="227" text-anchor="middle">Reserves · Obligation</text>
+  <text class="label-sm" x="1050" y="247" text-anchor="middle">Supply · Borrow</text>
+  <text class="label-sm" x="1050" y="265" text-anchor="middle">Health Factor · LTV</text>
+
+  <!-- SOLANA: RPC -->
+  <rect class="panel-success" x="950" y="295" width="200" height="110" rx="10"/>
+  <text class="label-strong" x="1050" y="328" text-anchor="middle">Helius RPC</text>
+  <text class="label-sm" x="1050" y="350" text-anchor="middle">sendTransaction</text>
+  <text class="label-sm" x="1050" y="368" text-anchor="middle">simulateTransaction</text>
+  <text class="label-sm" x="1050" y="386" text-anchor="middle">getSignatureStatuses</text>
+
+  <!-- FLOW ARROWS -->
+  <!-- UI → /api/chat -->
+  <path class="flow-arrow" d="M 250 200 L 348 200"/>
+  <text class="label-sm" x="299" y="192" text-anchor="middle">POST</text>
+  <!-- /api/chat → Tools -->
+  <path class="flow-arrow" d="M 550 220 L 648 220"/>
+  <text class="label-sm" x="599" y="212" text-anchor="middle">tool call</text>
+  <!-- Tools → /api/rpc (read path) -->
+  <path class="flow-arrow" d="M 650 330 L 552 350"/>
+  <text class="label-sm" x="605" y="332" text-anchor="middle">RPC</text>
+  <!-- /api/rpc → Helius -->
+  <path class="flow-arrow" d="M 550 350 L 948 350"/>
+  <!-- Tools → Kamino -->
+  <path class="flow-arrow" d="M 850 205 L 948 205"/>
+  <text class="label-sm" x="899" y="197" text-anchor="middle">reads on-chain</text>
+  <!-- Wallet → /api/rpc (sendTransaction) -->
+  <path class="flow-arrow" d="M 250 350 L 348 350"/>
+  <text class="label-sm" x="299" y="342" text-anchor="middle">signed tx</text>
+  <!-- /api/chat → UI (stream) -->
+  <path class="flow-arrow-return" d="M 348 245 L 250 245"/>
+  <text class="annotation" x="299" y="260" text-anchor="middle">SSE stream</text>
+  <!-- UI → Wallet (handoff) -->
+  <path class="flow-arrow-return" d="M 150 275 L 150 294"/>
+  <!-- Helius → Kamino (TX lands) -->
+  <path class="flow-arrow-return" d="M 1050 295 L 1050 278"/>
+
+  <!-- BOTTOM: user prompt example -->
+  <rect class="panel-muted" x="50" y="500" width="1100" height="180" rx="12"/>
+  <text class="label-strong" x="75" y="535">Example flow · user types <tspan class="label-mono">"Deposit 5 USDC into Kamino"</tspan></text>
+
+  <text class="label" x="75" y="570">1.</text>
+  <text class="label-sm" x="100" y="570">UI streams prompt to <tspan class="label-mono">/api/chat</tspan> →</text>
+  <text class="label" x="75" y="590">2.</text>
+  <text class="label-sm" x="100" y="590">LLM calls <tspan class="label-mono">buildDeposit</tspan> — klend-sdk compiles v0 tx, preflight simulates →</text>
+  <text class="label" x="75" y="610">3.</text>
+  <text class="label-sm" x="100" y="610">Base64 wire tx streams back, UI renders a <tspan class="label-mono">Sign &amp; Send</tspan> card →</text>
+  <text class="label" x="75" y="630">4.</text>
+  <text class="label-sm" x="100" y="630">Wallet signs client-side → <tspan class="label-mono">/api/rpc</tspan> forwards to Helius · <tspan class="label-mono">sendTransaction</tspan> →</text>
+  <text class="label" x="75" y="650">5.</text>
+  <text class="label-sm" x="100" y="650">UI polls <tspan class="label-mono">getSignatureStatuses</tspan> over HTTP until <tspan class="label-mono-green">confirmed</tspan> (no WS — Vercel can't upgrade) →</text>
+  <text class="label" x="75" y="670">6.</text>
+  <text class="label-sm" x="100" y="670">Card flips to <tspan class="label-mono-green">Confirmed on mainnet</tspan> with a Solscan link.</text>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import ChatHeader from './components/chat/ChatHeader';
 import ChatInputShell from './components/chat/ChatInputShell';
 import MessageBubble from './components/chat/MessageBubble';
 import EmptyState from './components/EmptyState';
+import PitchPage from './components/pitch/PitchPage';
 import { useChat } from './hooks/useChat';
 
 function AppContent() {
@@ -102,6 +103,16 @@ function AppContent() {
 }
 
 export default function App() {
+  if (typeof window !== 'undefined' && window.location.pathname === '/pitch') {
+    return (
+      <>
+        <PitchPage />
+        <Analytics />
+        <SpeedInsights />
+      </>
+    );
+  }
+
   return (
     <SolanaWalletProvider>
       <AppContent />

--- a/src/components/pitch/PitchPage.test.tsx
+++ b/src/components/pitch/PitchPage.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import PitchPage from './PitchPage';
+
+describe('PitchPage', () => {
+  it('renders the hero headline with Kamino accent', () => {
+    render(<PitchPage />);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      /Kami — AI DeFi Co-Pilot for/i,
+    );
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/Kamino\./i);
+  });
+
+  it('renders the eitherway/kamino/frontier kicker', () => {
+    render(<PitchPage />);
+    expect(screen.getByText(/eitherway · kamino · frontier hackathon 2026/i)).toBeInTheDocument();
+  });
+
+  it('renders all 10 numbered section labels', () => {
+    render(<PitchPage />);
+    for (let i = 1; i <= 10; i++) {
+      const padded = String(i).padStart(2, '0');
+      expect(screen.getByText(new RegExp(`\\[${padded} /`, 'i'))).toBeInTheDocument();
+    }
+  });
+
+  it('renders the demo video element with correct src + poster + controls', () => {
+    const { container } = render(<PitchPage />);
+    const video = container.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video?.getAttribute('src')).toContain('kami-walkthrough.mp4');
+    expect(video?.getAttribute('poster')).toContain('kami-walkthrough-poster.jpg');
+    expect(video?.hasAttribute('controls')).toBe(true);
+    expect(video?.getAttribute('preload')).toBe('metadata');
+  });
+
+  it('renders all 7 Kamino tools by name', () => {
+    render(<PitchPage />);
+    const tools = [
+      'getPortfolio',
+      'findYield',
+      'simulateHealth',
+      'buildDeposit',
+      'buildBorrow',
+      'buildRepay',
+      'buildWithdraw',
+    ];
+    tools.forEach((tool) => {
+      expect(screen.getByText(new RegExp(`\\d+\\. ${tool}`))).toBeInTheDocument();
+    });
+  });
+
+  it('renders all 4 mainnet tx signatures with Solscan links', () => {
+    render(<PitchPage />);
+    const sigs = [
+      ['3kKWBmN7eV', '3kKWBmN7eV…gGkJ1'],
+      ['4JoccMqAHq', '4JoccMqAHq…b2SZP'],
+      ['25YyumRhTk', '25YyumRhTk…EtGfZ'],
+      ['4B3nBa6GLS', '4B3nBa6GLS…U3QSc'],
+    ];
+    sigs.forEach(([sig, label]) => {
+      const link = screen.getByText(label).closest('a');
+      expect(link?.getAttribute('href')).toBe(`https://solscan.io/tx/${sig}`);
+    });
+  });
+
+  it('marks the hero (first) tx with star prefix', () => {
+    render(<PitchPage />);
+    const heroLink = screen.getByText('3kKWBmN7eV…gGkJ1').closest('a');
+    expect(heroLink?.textContent).toContain('★');
+  });
+
+  it('renders all 6 sponsor names', () => {
+    render(<PitchPage />);
+    const sponsors = ['Eitherway', 'Kamino', 'Solflare', 'Helius', 'Vercel', 'Anthropic'];
+    sponsors.forEach((sponsor) => {
+      expect(screen.getByText(sponsor)).toBeInTheDocument();
+    });
+  });
+
+  it('renders the architecture SVG via /architecture.svg', () => {
+    const { container } = render(<PitchPage />);
+    const img = container.querySelector('img[alt*="architecture"]');
+    expect(img?.getAttribute('src')).toBe('/architecture.svg');
+  });
+
+  it('renders the integration docs link in section 05 + section 10', () => {
+    render(<PitchPage />);
+    const links = screen.getAllByRole('link', { name: /kamino-integration\.md/i });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    links.forEach((link) => {
+      expect(link.getAttribute('href')).toBe(
+        'https://github.com/RECTOR-LABS/kami/blob/main/docs/kamino-integration.md',
+      );
+    });
+  });
+
+  it('renders the GitHub source link', () => {
+    render(<PitchPage />);
+    const githubLinks = screen.getAllByRole('link', { name: /source.*MIT|RECTOR-LABS \/ kami/i });
+    expect(githubLinks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders the live URL primary CTA', () => {
+    render(<PitchPage />);
+    const liveCta = screen.getByRole('link', { name: /live demo/i });
+    expect(liveCta.getAttribute('href')).toBe('https://kami.rectorspace.com');
+  });
+
+  it('renders the footer with bounty context', () => {
+    render(<PitchPage />);
+    expect(
+      screen.getByText(/Eitherway Track · Frontier Hackathon 2026 · Kamino prize/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/pitch/PitchPage.tsx
+++ b/src/components/pitch/PitchPage.tsx
@@ -1,0 +1,457 @@
+import { ArrowRight, ArrowUpRight, Github, PlayCircle } from 'lucide-react';
+
+const LIVE_URL = 'https://kami.rectorspace.com';
+const REPO_URL = 'https://github.com/RECTOR-LABS/kami';
+const DEMO_VIDEO_URL =
+  'https://aheyudueboveptjv.public.blob.vercel-storage.com/demo/kami-walkthrough.mp4';
+const DEMO_POSTER_URL =
+  'https://aheyudueboveptjv.public.blob.vercel-storage.com/demo/kami-walkthrough-poster.jpg';
+const INTEGRATION_DOCS_URL =
+  'https://github.com/RECTOR-LABS/kami/blob/main/docs/kamino-integration.md';
+
+interface KaminoTool {
+  number: number;
+  name: string;
+  primitive: string;
+  purpose: string;
+}
+
+const KAMINO_TOOLS: KaminoTool[] = [
+  { number: 1, name: 'getPortfolio', primitive: 'market.getObligationByAddress', purpose: 'Wallet positions, debt, health factor.' },
+  { number: 2, name: 'findYield', primitive: 'KaminoMarket.reserves', purpose: 'Best supply / borrow APY across reserves.' },
+  { number: 3, name: 'simulateHealth', primitive: 'Obligation.simulateBorrowAndWithdrawAction', purpose: 'Project post-action LTV + HF before signing.' },
+  { number: 4, name: 'buildDeposit', primitive: 'KaminoAction.buildDepositTxns', purpose: 'Construct supply transaction.' },
+  { number: 5, name: 'buildBorrow', primitive: 'KaminoAction.buildBorrowTxns', purpose: 'Construct borrow transaction with HF guard.' },
+  { number: 6, name: 'buildRepay', primitive: 'KaminoAction.buildRepayTxns', purpose: 'Construct repay tx + auto-recover from dust floor.' },
+  { number: 7, name: 'buildWithdraw', primitive: 'KaminoAction.buildWithdrawTxns', purpose: 'Construct withdraw transaction.' },
+];
+
+interface MainnetTx {
+  sig: string;
+  shortSig: string;
+  label: string;
+  hero?: boolean;
+}
+
+const MAINNET_TXS: MainnetTx[] = [
+  { sig: '3kKWBmN7eV', shortSig: '3kKWBmN7eV…gGkJ1', label: 'buildRepay auto-recovery from NetValueRemainingTooSmall', hero: true },
+  { sig: '4JoccMqAHq', shortSig: '4JoccMqAHq…b2SZP', label: 'buildDeposit USDC into Kamino Main Market' },
+  { sig: '25YyumRhTk', shortSig: '25YyumRhTk…EtGfZ', label: 'buildDeposit follow-up' },
+  { sig: '4B3nBa6GLS', shortSig: '4B3nBa6GLS…U3QSc', label: 'buildDeposit baseline' },
+];
+
+interface Sponsor {
+  name: string;
+  role: string;
+}
+
+const SPONSORS: Sponsor[] = [
+  { name: 'Eitherway', role: 'Scaffold + deploy pipeline' },
+  { name: 'Kamino', role: 'klend SDK · Main Market' },
+  { name: 'Solflare', role: 'Featured wallet (Wallet Standard)' },
+  { name: 'Helius', role: 'RPC proxy + preflight simulation' },
+  { name: 'Vercel', role: 'Hosting · AI SDK · Blob storage' },
+  { name: 'Anthropic', role: 'Claude Sonnet 4.6 (via OpenRouter)' },
+];
+
+const PRODUCTION_QUALITY: { html: React.ReactNode }[] = [
+  { html: (<>Live in production at <a href={LIVE_URL} className="text-kami-amber border-b border-kami-amber/30 hover:text-kami-cream transition-colors">kami.rectorspace.com</a></>) },
+  { html: '320 tests passing · 3 typecheck targets · CI green on every push' },
+  { html: 'Security headers: CSP, HSTS (2y preload), X-CTO=nosniff, X-Frame=DENY, COOP, Permissions-Policy' },
+  { html: 'Rate-limited via Upstash-shimmed Redis on self-hosted VPS · 30/min chat · 120/min RPC · fail-open on outage' },
+  { html: '15-min uptime heartbeat workflow · GitLab auto-mirror · klend-sdk pin guard in CI' },
+  { html: 'Operating cost ~$25/mo · personally funded · sustainable past the bounty window' },
+  { html: 'Open source MIT' },
+];
+
+const ROADMAP: { html: React.ReactNode }[] = [
+  { html: 'Phantom adapter alongside Solflare.' },
+  { html: (<>Closeable obligation when <code className="font-mono text-sm text-kami-amber">klend</code> ships the upstream <code className="font-mono text-sm text-kami-amber">close_obligation</code> instruction.</>) },
+  { html: 'Conversation history persistence across devices (currently localStorage-only).' },
+  { html: 'Tutorial content mapping common Kamino workflows to natural-language commands.' },
+  { html: 'Phantom Blowfish review submission once the lead time fits.' },
+];
+
+function SectionGrid({
+  label,
+  title,
+  children,
+  border = true,
+}: {
+  label: string;
+  title: string;
+  children: React.ReactNode;
+  border?: boolean;
+}) {
+  return (
+    <section
+      className={`py-24 lg:py-32 ${border ? 'border-b border-kami-cellBorder' : ''} lg:grid lg:grid-cols-[3fr_9fr] lg:gap-16 lg:items-start`}
+    >
+      <div className="font-mono text-kami-amber uppercase text-xs mb-8 lg:mb-0 lg:sticky lg:top-32 tracking-widest">
+        [{label}]
+      </div>
+      <div className="max-w-4xl w-full">
+        <h2 className="font-display text-4xl lg:text-5xl leading-tight mb-8 text-kami-cream">
+          {title}
+        </h2>
+        <div className="space-y-6">{children}</div>
+      </div>
+    </section>
+  );
+}
+
+function ToolCard({ tool }: { tool: KaminoTool }) {
+  return (
+    <div className="rounded-2xl bg-black/20 border border-kami-cellBorder p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_10px_30px_-10px_rgba(0,0,0,0.5)] transition-all duration-300 hover:border-kami-amber/40 hover:-translate-y-0.5 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_20px_40px_-15px_rgba(255,165,0,0.05)]">
+      <div className="font-mono text-kami-amber font-bold mb-3 text-sm">
+        {tool.number}. {tool.name}
+      </div>
+      <p className="text-sm text-kami-cream mb-4">{tool.purpose}</p>
+      <div className="font-mono text-xs text-kami-creamMuted pt-4 border-t border-kami-cellBorder/60 truncate">
+        → {tool.primitive}
+      </div>
+    </div>
+  );
+}
+
+function TxRow({ tx, isLast }: { tx: MainnetTx; isLast: boolean }) {
+  return (
+    <a
+      href={`https://solscan.io/tx/${tx.sig}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={[
+        'group flex flex-col md:flex-row md:items-center gap-4 p-5 md:p-6 transition-colors relative',
+        tx.hero
+          ? 'bg-kami-amberHaze/30 border-b border-kami-amber/40 hover:bg-kami-amber/10'
+          : 'hover:bg-white/5',
+        !tx.hero && !isLast ? 'border-b border-kami-cellBorder' : '',
+      ].join(' ')}
+    >
+      {tx.hero && <div className="absolute left-0 top-0 bottom-0 w-1 bg-kami-amber" aria-hidden="true" />}
+      <span
+        className={`font-mono text-sm flex-shrink-0 md:w-44 flex items-center gap-2 ${tx.hero ? 'text-kami-amber' : 'text-kami-cream'}`}
+      >
+        {tx.hero && <span className="text-lg" aria-hidden="true">★</span>}
+        {tx.shortSig}
+      </span>
+      <span
+        className={`text-sm flex-1 transition-colors ${tx.hero ? 'text-kami-cream' : 'text-kami-creamMuted group-hover:text-kami-cream'}`}
+      >
+        {tx.label}
+      </span>
+      <ArrowUpRight
+        className={`w-4 h-4 transition-opacity ${tx.hero ? 'text-kami-amber' : 'text-kami-creamMuted'} opacity-0 group-hover:opacity-100`}
+        aria-hidden="true"
+      />
+    </a>
+  );
+}
+
+function SponsorBadge({ sponsor }: { sponsor: Sponsor }) {
+  return (
+    <div>
+      <div className="font-display text-xl uppercase tracking-tight mb-2 text-kami-cream">
+        {sponsor.name}
+      </div>
+      <div className="font-mono text-xs text-kami-creamMuted">{sponsor.role}</div>
+    </div>
+  );
+}
+
+interface LinkCardProps {
+  label: string;
+  title: string;
+  href: string;
+  external?: boolean;
+  icon: React.ReactNode;
+}
+
+function LinkCard({ label, title, href, external = true, icon }: LinkCardProps) {
+  return (
+    <a
+      href={href}
+      {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+      className="group block p-8 rounded-2xl bg-black/20 border border-kami-cellBorder shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_10px_30px_-10px_rgba(0,0,0,0.5)] transition-all duration-300 hover:border-kami-amber/40 hover:-translate-y-0.5 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_20px_40px_-15px_rgba(255,165,0,0.05)]"
+    >
+      <div className="flex justify-between items-start mb-6">
+        <span className="font-mono text-xs text-kami-creamMuted uppercase tracking-widest">
+          {label}
+        </span>
+        <span className="text-kami-creamMuted group-hover:text-kami-amber transition-colors">
+          {icon}
+        </span>
+      </div>
+      <div className="font-display text-2xl text-kami-cream group-hover:text-white transition-colors">
+        {title}
+      </div>
+    </a>
+  );
+}
+
+export default function PitchPage() {
+  return (
+    <div className="min-h-screen bg-kami-sepiaBg text-kami-cream font-sans antialiased relative overflow-x-hidden">
+      <div
+        className="fixed inset-0 pointer-events-none -z-10"
+        style={{
+          backgroundImage:
+            'linear-gradient(to right, rgba(245,230,211,0.03) 1px, transparent 1px), linear-gradient(to bottom, rgba(245,230,211,0.03) 1px, transparent 1px)',
+          backgroundSize: '32px 32px',
+        }}
+        aria-hidden="true"
+      />
+      <div
+        className="fixed -top-32 -left-32 w-[40vw] h-[40vw] rounded-full bg-kami-amber blur-[150px] opacity-15 pointer-events-none -z-10 mix-blend-color-dodge"
+        aria-hidden="true"
+      />
+
+      <nav className="fixed top-0 w-full z-50 bg-kami-sepiaBg/80 backdrop-blur-md border-b border-kami-cellBorder">
+        <div className="max-w-[80rem] mx-auto px-6 py-4 flex justify-between items-center font-mono text-xs uppercase tracking-widest">
+          <a href="/" className="text-kami-creamMuted hover:text-kami-cream transition-colors">
+            ← KAMI · v1.0 · MAINNET
+          </a>
+          <span className="text-kami-amber">[pitch / judges]</span>
+        </div>
+      </nav>
+
+      <main className="max-w-[80rem] mx-auto px-6 pb-24">
+        <header className="min-h-[100dvh] flex flex-col justify-center pt-24 pb-32 border-b border-kami-cellBorder">
+          <div className="max-w-5xl">
+            <p className="font-mono text-kami-creamMuted text-sm uppercase tracking-widest mb-8 animate-cascade-up [animation-delay:100ms]">
+              [eitherway · kamino · frontier hackathon 2026]
+            </p>
+            <h1 className="font-display font-medium text-6xl md:text-[6rem] leading-[0.9] tracking-tighter mb-10 text-kami-cream animate-cascade-up [animation-delay:200ms]">
+              Kami — AI DeFi Co-Pilot for
+              <br />
+              <span className="text-kami-amber inline-block mt-2">Kamino.</span>
+            </h1>
+            <p className="text-xl md:text-2xl text-kami-creamMuted max-w-3xl mb-12 leading-relaxed animate-cascade-up [animation-delay:300ms]">
+              Type plain English. Kami orchestrates real klend-sdk calls and returns
+              ready-to-sign mainnet transactions. No dashboard scraping. No manual SDK plumbing.
+            </p>
+            <div className="flex flex-wrap gap-4 font-medium text-sm animate-cascade-up [animation-delay:400ms]">
+              <a
+                href={LIVE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-8 py-4 bg-kami-amber text-kami-sepiaBg rounded-xl hover:bg-kami-cream transition-colors flex items-center gap-2 group font-bold"
+              >
+                Live demo
+                <ArrowRight
+                  className="w-4 h-4 group-hover:translate-x-1 transition-transform"
+                  aria-hidden="true"
+                />
+              </a>
+              <a
+                href="#demo"
+                className="px-8 py-4 border border-kami-cellBorder text-kami-cream hover:bg-white/5 rounded-xl transition-colors flex items-center gap-2"
+              >
+                Watch demo · 3 min
+                <PlayCircle className="w-5 h-5 text-kami-amber" aria-hidden="true" />
+              </a>
+              <a
+                href={REPO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-6 py-4 border border-kami-cellBorder text-kami-creamMuted hover:text-kami-cream hover:border-kami-cream/30 rounded-xl transition-colors flex items-center gap-2"
+              >
+                Source · MIT
+                <Github className="w-5 h-5" aria-hidden="true" />
+              </a>
+            </div>
+          </div>
+        </header>
+
+        <SectionGrid label="01 / problem" title="DeFi power-users carry the operational overhead.">
+          <p className="text-kami-creamMuted text-lg leading-relaxed">
+            Managing intricate Kamino positions requires juggling sprawling dashboards,
+            cross-referencing on-chain data, and often spinning up custom scripts. Every action
+            demands constant mental math to track Loan-to-Value (LTV), health factors, and
+            potential slippage.
+          </p>
+          <p className="text-kami-creamMuted text-lg leading-relaxed">
+            This cognitive load pushes new users away and slows down veterans who need to
+            execute strategies quickly. The protocol is powerful, but interacting with its
+            primitives remains fundamentally decoupled from human intent.
+          </p>
+        </SectionGrid>
+
+        <SectionGrid label="02 / solution" title="One sentence in. One signed transaction out.">
+          <p className="text-kami-creamMuted text-lg leading-relaxed">
+            Kami bridges the gap. Claude Sonnet 4.6 (via OpenRouter) reasons about your
+            portfolio, market conditions, and risk. It autonomously invokes specialized Kamino
+            tools and emits a verified, ready-to-sign mainnet transaction directly to your
+            wallet.
+          </p>
+          <div className="bg-black/60 border border-kami-cellBorder rounded-2xl p-8 font-mono text-sm space-y-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
+            {[
+              'deposit 5 USDC into Kamino Main Market',
+              'show my positions and warn me if my health factor drops below 1.5',
+              'repay everything I owe in SOL',
+            ].map((prompt) => (
+              <div key={prompt} className="flex gap-4">
+                <span className="text-kami-amber font-bold">&gt;</span>
+                <span className="text-kami-cream">{prompt}</span>
+              </div>
+            ))}
+          </div>
+        </SectionGrid>
+
+        <section id="demo" className="py-24 lg:py-32 border-b border-kami-cellBorder">
+          <div className="font-mono text-kami-amber uppercase text-xs mb-10 text-center lg:text-left tracking-widest">
+            [03 / demo] — 3-minute walkthrough.
+          </div>
+          <div className="relative w-full aspect-[1280/1026] max-w-5xl mx-auto rounded-3xl overflow-hidden shadow-[0_20px_50px_-15px_rgba(255,165,0,0.1)] border border-kami-cellBorder bg-black">
+            <video
+              src={DEMO_VIDEO_URL}
+              poster={DEMO_POSTER_URL}
+              controls
+              preload="metadata"
+              playsInline
+              className="w-full h-full object-cover"
+            />
+          </div>
+          <p className="mt-6 text-center font-mono text-xs text-kami-creamMuted uppercase tracking-widest">
+            [silent walkthrough · click to play · supports browser fullscreen]
+          </p>
+        </section>
+
+        <SectionGrid label="04 / how it works" title="LLM-driven tool orchestration on mainnet.">
+          <p className="text-kami-creamMuted text-lg leading-relaxed">
+            User intent flows through the Vercel AI SDK to Claude Sonnet 4.6, which possesses
+            contextual awareness of 7 bespoke Kamino tools. It decides the execution path,
+            interacting with the raw <code className="font-mono text-kami-amber">klend-sdk</code>{' '}
+            to build the instruction set. The user signs, and the Helius RPC proxy broadcasts
+            the execution.
+          </p>
+          <div className="bg-[#120E0B] border border-kami-cellBorder rounded-2xl p-6 lg:p-12 flex items-center justify-center min-h-[300px]">
+            <img
+              src="/architecture.svg"
+              alt="Kami architecture: user intent → LLM → 7 Kamino tools → klend-sdk → wallet sign → Helius broadcast"
+              className="max-w-full opacity-90 mx-auto"
+            />
+          </div>
+        </SectionGrid>
+
+        <SectionGrid label="05 / integration depth" title="Seven tools, mapped 1:1 to klend-sdk.">
+          <p className="text-kami-creamMuted text-lg leading-relaxed">
+            Every write call is routed to{' '}
+            <code className="font-mono text-kami-amber">KaminoAction.build*Txns</code> directly.
+            There is no intermediary middleware and no hand-rolled instructions. The LLM
+            processes structured preflight errors (like{' '}
+            <code className="font-mono text-kami-amber">NetValueRemainingTooSmall</code> dust
+            floors, oracle staleness, or slippage bounds) and computes recovery paths via the
+            autonomous conversation context.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {KAMINO_TOOLS.map((tool) => (
+              <ToolCard key={tool.name} tool={tool} />
+            ))}
+          </div>
+          <a
+            href={INTEGRATION_DOCS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex font-mono text-xs text-kami-creamMuted hover:text-kami-amber transition-colors items-center gap-2 group mt-2"
+          >
+            Full mapping documented in docs/kamino-integration.md
+            <ArrowRight
+              className="w-4 h-4 group-hover:translate-x-1 transition-transform"
+              aria-hidden="true"
+            />
+          </a>
+        </SectionGrid>
+
+        <SectionGrid label="06 / mainnet validation" title="Confirmed Kami-broadcast transactions.">
+          <p className="text-kami-creamMuted text-lg leading-relaxed">
+            The defining capability. In the leading transaction,{' '}
+            <code className="font-mono text-kami-amber">buildRepay</code> predictably fails due
+            to an oracle-induced dust floor. The LLM catches the preflight error, explicitly
+            invokes <code className="font-mono text-kami-amber">getPortfolio</code> to calculate
+            the buffer margin, recalculates, and immediately returns a successful, signable
+            payload — all within a single generative turn.
+          </p>
+          <div className="flex flex-col rounded-2xl overflow-hidden border border-kami-cellBorder bg-black/20">
+            {MAINNET_TXS.map((tx, i) => (
+              <TxRow key={tx.sig} tx={tx} isLast={i === MAINNET_TXS.length - 1} />
+            ))}
+          </div>
+        </SectionGrid>
+
+        <SectionGrid label="07 / built on" title="Sponsors stack.">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-12">
+            {SPONSORS.map((sponsor) => (
+              <SponsorBadge key={sponsor.name} sponsor={sponsor} />
+            ))}
+          </div>
+        </SectionGrid>
+
+        <SectionGrid label="08 / production quality" title="Already live. Already hardened.">
+          <ul className="space-y-4 font-mono text-sm">
+            {PRODUCTION_QUALITY.map((item, i) => (
+              <li key={i} className="flex items-start gap-4">
+                <span className="text-kami-amber mt-0.5" aria-hidden="true">✓</span>
+                <span className="text-kami-creamMuted">{item.html}</span>
+              </li>
+            ))}
+          </ul>
+        </SectionGrid>
+
+        <SectionGrid label="09 / what's next" title="Post-bounty roadmap.">
+          <ul className="space-y-6 text-kami-creamMuted">
+            {ROADMAP.map((item, i) => (
+              <li key={i} className="flex items-start gap-4">
+                <span className="font-mono text-kami-amber mt-1" aria-hidden="true">▸</span>
+                <span className="text-lg leading-relaxed">{item.html}</span>
+              </li>
+            ))}
+          </ul>
+        </SectionGrid>
+
+        <SectionGrid label="10 / links" title="Everything in one place." border={false}>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <LinkCard
+              label="LIVE APP"
+              title="kami.rectorspace.com"
+              href={LIVE_URL}
+              icon={<ArrowUpRight className="w-5 h-5 group-hover:translate-x-1 group-hover:-translate-y-1 transition-transform" aria-hidden="true" />}
+            />
+            <LinkCard
+              label="SOURCE CODE"
+              title="RECTOR-LABS / kami"
+              href={REPO_URL}
+              icon={<Github className="w-5 h-5 group-hover:scale-110 transition-transform" aria-hidden="true" />}
+            />
+            <LinkCard
+              label="INTEGRATION DOCS"
+              title="kamino-integration.md"
+              href={INTEGRATION_DOCS_URL}
+              icon={<ArrowUpRight className="w-5 h-5 group-hover:translate-x-1 group-hover:-translate-y-1 transition-transform" aria-hidden="true" />}
+            />
+            <LinkCard
+              label="DEMO VIDEO"
+              title="3-min walkthrough"
+              href="#demo"
+              external={false}
+              icon={<PlayCircle className="w-5 h-5 group-hover:scale-110 transition-transform" aria-hidden="true" />}
+            />
+          </div>
+        </SectionGrid>
+      </main>
+
+      <footer className="border-t border-kami-cellBorder pt-8 pb-12 px-6 relative z-10 flex flex-col items-center justify-center">
+        <p className="font-mono text-xs text-kami-creamMuted text-center max-w-lg mb-4">
+          Built for the Eitherway Track · Frontier Hackathon 2026 · Kamino prize
+        </p>
+        <a
+          href="/"
+          className="font-mono text-xs text-kami-amber hover:text-kami-cream transition-colors flex items-center gap-1 group"
+        >
+          return to live app
+          <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
+        </a>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a dedicated **/pitch** route built for Eitherway-Kamino bounty judges to skim the full Kami story in 2-3 minutes.

**Live preview after merge:** https://kami.rectorspace.com/pitch

## Why

Judges hit the landing with 26 other submissions to review. The bento landing pitches Kami to *users*; this page pitches it to *judges* with the structure they need (problem · solution · integration depth · mainnet validation · production quality · roadmap).

Same domain as the live app. Polished pitch that doubles as a share link in the tweet thread, Telegram ping, and the Superteam form's Presentation Link field.

## Design provenance

Design generated via **aidesigner MCP** from the Kami brand kit (sepia/amber/cream + Unbounded/Inter/JetBrains Mono — same as the bento landing), then ported to React with Lucide icons and the project's existing kami-* Tailwind tokens.

Aidesigner run id: `f585708e-c69c-4fae-95f9-e7d28e63ac51` (1 credit consumed, 70 remain).

## Implementation

- **Routing:** single conditional in `App.tsx` (no React Router dep) — Vercel's SPA fallback serves `/pitch` → `index.html` → App reads `window.location.pathname` and renders `PitchPage` instead of the wallet-provider-wrapped chat shell.
- **PitchPage component:** `src/components/pitch/PitchPage.tsx` — single file with internal `SectionGrid`, `ToolCard`, `TxRow`, `SponsorBadge`, `LinkCard` helpers.
- **Asymmetric editorial grid:** `lg:grid-cols-[3fr_9fr]` with sticky section labels on desktop. Mobile: stacked.
- **Architecture diagram:** copied `assets/architecture.svg` → `public/architecture.svg` so Vite serves it at `/architecture.svg`.
- **No new dependencies, no Tailwind config changes.** Uses existing `kami-sepiaBg`, `kami-cream`, `kami-creamMuted`, `kami-amber`, `kami-cellBorder`, `kami-amberHaze`, `font-display`, `font-mono`, `font-sans`, and the existing `cascade-up` keyframe.

## Sections (in order)

1. **Hero** — text-7xl Unbounded headline ("Kamino." in amber), 3 CTAs (live · demo · source).
2. **[01 / problem]** — DeFi power-users carry the operational overhead.
3. **[02 / solution]** — One sentence in. One signed transaction out (with 3 example prompts in a code block).
4. **[03 / demo]** — embedded 3-min walkthrough (same Vercel Blob URL as the bento landing).
5. **[04 / how it works]** — architecture diagram + LLM-orchestration narrative.
6. **[05 / integration depth]** — all 7 Kamino tools mapped 1:1 to klend-sdk primitives in a 2-col card grid.
7. **[06 / mainnet validation]** — 4 confirmed Kami-broadcast tx with Solscan links; hero row (`3kKWBmN7eV…gGkJ1` dust-floor recovery) gets amber-tinted bg + accent bar.
8. **[07 / built on]** — 6-sponsor 3-col grid.
9. **[08 / production quality]** — 7-item amber ✓ checklist (live URL, 320 tests, security headers, rate-limit, uptime heartbeat, op cost, MIT).
10. **[09 / what's next]** — 5-item amber ▸ post-bounty roadmap.
11. **[10 / links]** — 2-col link card grid (live · source · docs · demo).

## Verification

- `pnpm test:run` → **333 passed (was 320, +13 from PitchPage.test.tsx)**.
- `pnpm exec tsc --noEmit` → silent.
- `pnpm exec tsc -p server/tsconfig.json --noEmit` → silent.
- Verified locally at `http://localhost:5173/pitch` — hero renders identical to the aidesigner preview, sticky grid works, all sections present.

## Test plan

- [ ] After merge → Vercel auto-deploys → visit https://kami.rectorspace.com/pitch.
- [ ] Hard-refresh (Cmd+Shift+R).
- [ ] Hero loads at full size, three CTAs work, "Kamino." is amber.
- [ ] Scroll through all 10 sections — sticky `[NN / xxx]` labels track on the left at desktop.
- [ ] Video poster renders + plays on click.
- [ ] All 4 mainnet tx links open Solscan in new tabs; hero row visually distinct.
- [ ] Architecture diagram renders.
- [ ] Footer "return to live app →" navigates back to `/`.
- [ ] Mobile: sections stack, video scales, link cards stack.