### PR TITLE
fix(vercel): add SPA rewrite for /pitch and client routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/((?!api/).*)", "destination": "/index.html" }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- `vercel.json` had no `rewrites` block, so Vercel returned 404 for any path that didn't match a static file or function — including `/pitch` (PR #59), which is detected purely client-side via `window.location.pathname` in `App.tsx`.
- Adds a single negative-lookahead rewrite: `/((?!api/).*) → /index.html`. Keeps `/api/*` function routes untouched; every other path falls through to the SPA shell so React Router (and App.tsx's pitch detection) take over.

## Why now
Pre-Colosseum submission. Submission packet references `/pitch` as the judge-targeted deck — a 404 on that path would be the first thing a judge sees if they click the link from the README or the X thread.

## Test plan
- [ ] Vercel preview deploy succeeds
- [ ] `curl -sI <preview>/pitch` → 200 (currently 404 on prod)
- [ ] `curl -sI <preview>/api/rpc` → 200 (function routes still resolve)
- [ ] After merge: `curl -sI https://kami.rectorspace.com/pitch` → 200
- [ ] After merge: `curl -sI https://kami.rectorspace.com/api/rpc` → rate-limit headers still present (`X-RateLimit-Limit: 120`)